### PR TITLE
Update overhead timing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The default timer object can be retrieved with `TimerOutputs.get_defaultimer()`.
 
 ## Overhead
 
-There is a small overhead in timing a section (0.25 μs) which means that this package is not suitable for measuring sections that finish very quickly.
+There is a small overhead in timing a section (≈ 70 ns) which means that this package is not suitable for measuring sections that finish very quickly.
 For proper benchmarking you want to use a more suitable tool like [*BenchmarkTools*](https://github.com/JuliaCI/BenchmarkTools.jl).
 
 ## Author


### PR DESCRIPTION
Probably changed by #13, now I get this:

```
julia> function foo()
           @timeit "test" a = 1
       end
foo (generic function with 1 method)

julia> function bar()
           a = 1
       end
bar (generic function with 1 method)

julia> @btime foo(); @btime bar();
  69.010 ns (0 allocations: 0 bytes)
  0.025 ns (0 allocations: 0 bytes)

```