### PR TITLE
Fix noop timer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,10 +302,10 @@ There is, however, no simple way to redefine how `@timeit` should work after pre
 A simple solution is to define your own macro (here `@timeit2`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
 
 ```jl
-timestuff = false
+ENABLE_TIMING = false
 
 macro timeit2(exprs...)
-    if timestuff
+    if ENABLE_TIMING
         return :(@timeit($(esc.(exprs)...)))
     else
         return esc(exprs[end])
@@ -313,7 +313,7 @@ macro timeit2(exprs...)
 end
 ```
 
-This will create a macro that "does nothing" (just returns the expression) depending on the value of `timestuff` when the macro is called.
+This will create a macro that "does nothing" (just returns the expression) depending on the value of `ENABLE_TIMING` when the macro is expanded.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -302,10 +302,10 @@ There is, however, no simple way to redefine how `@timeit` should work after pre
 A simple solution is to define your own macro (here `@timeit2`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
 
 ```jl
-ENABLE_TIMING = false
+ENABLE_TIMINGS = false
 
 macro timeit2(exprs...)
-    if ENABLE_TIMING
+    if ENABLE_TIMINGS
         return :(@timeit($(esc.(exprs)...)))
     else
         return esc(exprs[end])
@@ -313,7 +313,7 @@ macro timeit2(exprs...)
 end
 ```
 
-This will create a macro that "does nothing" (just returns the expression) depending on the value of `ENABLE_TIMING` when the macro is expanded.
+This will create a macro that "does nothing" (just returns the expression) depending on the value of `ENABLE_TIMINGS` when the macro is expanded.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -299,12 +299,12 @@ For proper benchmarking you want to use a more suitable tool like [*BenchmarkToo
 
 It is sometimes desireable to be able "turn on and off" the `@timeit` macro.
 There is, however, no simple way to redefine how `@timeit` should work after precompilation.
-A simple solution is to define your own macro (here `@timeit2`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
+A simple solution is to define your own macro (here `@mytimeit`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
 
 ```jl
 ENABLE_TIMINGS = false
 
-macro timeit2(exprs...)
+macro mytimeit(exprs...)
     if ENABLE_TIMINGS
         return :(@timeit($(esc.(exprs)...)))
     else

--- a/README.md
+++ b/README.md
@@ -302,18 +302,18 @@ There is, however, no simple way to redefine how `@timeit` should work after pre
 A simple solution is to define your own macro (here `@timeit2`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
 
 ```jl
-DEBUG = false # true
+timestuff = false
 
-macro timeit2(expr)
-    if DEBUG
-        return :($(esc(expr)))
+macro timeit2(exprs...)
+    if timestuff
+        return :(@timeit($(esc.(exprs)...)))
     else
-        return :(@timeit($(esc(expr))))
+        return esc(exprs[end])
     end
 end
 ```
 
-This will create a macro that "does nothing" (just returns the expression) depending on the value of `DEBUG` when the macro is defined.
+This will create a macro that "does nothing" (just returns the expression) depending on the value of `timestuff` when the macro is called.
 
 ## Author
 


### PR DESCRIPTION
Using the `@timeit2` in the README
```julia
@timeit2 "sleep" sleep(1.0)
ERROR: MethodError: no method matching @timeit2(::String, ::Expr)
Closest candidates are:
  @timeit2(::ANY) at REPL[3]:2
```
Using the one here
```julia
timestuff = false
@timeit2 "sleep" sleep(1.0)
print_timer() # shows nothing
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations
                   ──────────────────────   ───────────────────────
 Tot / % measured:     16351s / 0.00%            209MiB / 0.00%

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 ──────────────────────────────────────────────────────────────────
```
```
timestuff = true
@timeit2 "sleep" sleep(1.0)
print_timer() # works
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations
                   ──────────────────────   ───────────────────────
 Tot / % measured:     16367s / 0.01%            213MiB / 0.00%

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 sleep          1    1.00s   100%   1.00s   1.20KiB  100%   1.20KiB
 ──────────────────────────────────────────────────────────────────
```
