### PR TITLE
Two fixes needed to run inside the compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,17 @@ language: julia
 os:
   - linux
   - osx
-  
+
 julia:
-    - 0.6
     - nightly
-    
+
 matrix:
   allow_failures:
     - julia: nightly
-    
+
 notifications:
   email: false
-  
+
 # uncomment the following lines to override the default test script
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/README.md
+++ b/README.md
@@ -299,21 +299,21 @@ For proper benchmarking you want to use a more suitable tool like [*BenchmarkToo
 
 It is sometimes desireable to be able "turn on and off" the `@timeit` macro.
 There is, however, no simple way to redefine how `@timeit` should work after precompilation.
-A simple solution is to define your own macro (here `@timeit2`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
+A simple solution is to define your own macro (here `@mytimeit`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
 
 ```jl
-DEBUG = false # true
+ENABLE_TIMINGS = false
 
-macro timeit2(expr)
-    if DEBUG
-        return :($(esc(expr)))
+macro mytimeit(exprs...)
+    if ENABLE_TIMINGS
+        return :(@timeit($(esc.(exprs)...)))
     else
-        return :(@timeit($(esc(expr))))
+        return esc(exprs[end])
     end
 end
 ```
 
-This will create a macro that "does nothing" (just returns the expression) depending on the value of `DEBUG` when the macro is defined.
+This will create a macro that "does nothing" (just returns the expression) depending on the value of `ENABLE_TIMINGS` when the macro is expanded.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ end
 
 time_test()
 
-# a function version with `do` syntax for exception safety
+# exception safe
 function i_will_throw()
-    timeit(to, "throwing") do
+    @timeit to "throwing" do
         sleep(0.5)
         throw(error("this is fine..."))
         print("nope")
@@ -104,9 +104,9 @@ Similar information is available for allocations:
 
 ```
  ──────────────────────────────────────────────────────────────────────
-                               Time                   Allocations      
+                               Time                   Allocations
                        ──────────────────────   ───────────────────────
-   Tot / % measured:        5.09s / 56.0%            106MiB / 74.6%    
+   Tot / % measured:        5.09s / 56.0%            106MiB / 74.6%
 
  Section       ncalls     time   %tot     avg     alloc   %tot      avg
  ──────────────────────────────────────────────────────────────────────
@@ -125,7 +125,7 @@ Similar information is available for allocations:
 
 ## Settings for printing:
 
-The `print_timer([io::IO = STDOUT], to::TimerOutput, kwargs)`, (or `show`) takes a number of keyword arguments to change the output. They are listed here:
+The `print_timer([io::IO = stdout], to::TimerOutput, kwargs)`, (or `show`) takes a number of keyword arguments to change the output. They are listed here:
 
 * `title::String` ─ title for the timer
 * `allocations::Bool` ─ show the allocation columns (default `true`)
@@ -278,9 +278,9 @@ which prints:
 ```julia
 julia> print_timer()
  ───────────────────────────────────────────────────────────────────
-                            Time                   Allocations      
+                            Time                   Allocations
                     ──────────────────────   ───────────────────────
-  Tot / % measured:      276ms / 44.3%            422KiB / 0.21%    
+  Tot / % measured:      276ms / 44.3%            422KiB / 0.21%
 
  Section    ncalls     time   %tot     avg     alloc   %tot      avg
  ───────────────────────────────────────────────────────────────────

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
+julia 0.7-
 Crayons
-Compat 0.41

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,8 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"TimerOutputs\");"
+      Pkg.clone(pwd(), \"TimerOutputs\");
+      Pkg.test(\"TimerOutputs\")"
 
 
 test_script:

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -182,9 +182,13 @@ function timer_expr(to::Union{Symbol,Expr}, label, ex::Expr)
         local accumulated_data = $(push!)($(esc(to)), $(esc(label)))
         local b₀ = $(gc_bytes)()
         local t₀ = $(time_ns)()
-        local val = $(esc(ex))
-        $(do_accumulate!)(accumulated_data, t₀, b₀)
-        $(pop!)($(esc(to)))
+        local val
+        $(Expr(:tryfinally,
+            :(val = $(esc(ex))),
+            quote
+                $(do_accumulate!)(accumulated_data, t₀, b₀)
+                $(pop!)($(esc(to)))
+            end))
         val
     end
 end

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -203,6 +203,8 @@ function reset_timer!(to::TimerOutput)
     return to
 end
 
+# We can remove this now that the @timeit macro is exception safe.
+# Doesn't hurt to keep it for a while though
 timeit(f::Function, label::String) = timeit(f, DEFAULT_TIMER, label)
 function timeit(f::Function, to::TimerOutput, label::String)
     accumulated_data = push!(to, label)

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -6,8 +6,8 @@ import Base: show, time_ns, gc_bytes
 export TimerOutput, @timeit, reset_timer!, print_timer, timeit
 
 using Crayons
-using Compat.Printf
-using Compat.Unicode
+using Printf
+using Unicode
 
 
 include("TimerOutput.jl")

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,9 +1,9 @@
-print_timer(; kwargs...) = show(STDOUT, DEFAULT_TIMER; kwargs...)
+print_timer(; kwargs...) = show(stdout, DEFAULT_TIMER; kwargs...)
 print_timer(io::IO; kwargs...) = show(io, DEFAULT_TIMER; kwargs...)
 print_timer(io::IO, to::TimerOutput; kwargs...) = show(io, to; kwargs...)
-print_timer(to::TimerOutput; kwargs...) = show(STDOUT, to; kwargs...)
+print_timer(to::TimerOutput; kwargs...) = show(stdout, to; kwargs...)
 
-Base.show(to::TimerOutput; kwargs...) = show(STDOUT, to; kwargs...)
+Base.show(to::TimerOutput; kwargs...) = show(stdout, to; kwargs...)
 function Base.show(io::IO, to::TimerOutput; allocations::Bool = true, sortby::Symbol = :time, linechars::Symbol = :unicode, compact::Bool = false, title::String = "")
     sortby  in (:time, :ncalls, :allocations, :name) || throw(ArgumentError("sortby should be :time, :allocations, :ncalls or :name, got $sortby"))
     linechars in (:unicode, :ascii)                  || throw(ArgumentError("linechars should be :unicode or :ascii, got $linechars"))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -64,7 +64,7 @@ function prettypercent(nominator, denominator)
     return str
 end
 
-function prettycount(t::Int)
+function prettycount(t::Integer)
     if t < 1000
         return string(t)
     elseif t < 1000^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,4 +248,16 @@ for (c, str) in ((9999, "10.0k"), (99999, "100k"),
     @test prettycount(c) == str
 end
 
+# `continue` inside a timeit section
+to_continue = TimerOutput()
+function continue_test()
+   for i = 1:10
+       @timeit to_continue "x" @timeit to_continue "test" begin
+           continue
+       end
+   end
+end
+continue_test()
+@test isempty(to_continue.inner_timers["x"].inner_timers["test"].inner_timers)
+
 end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,16 @@ import TimerOutputs: DEFAULT_TIMER, ncalls, flatten,
 
 reset_timer!()
 
+# Timing from modules that don't import much
+baremodule NoImports
+    using TimerOutputs
+    using Base: sleep
+    @timeit "baresleep" sleep(0.1)
+end
+
 @testset "TimerOutput" begin
+
+@test "baresleep" in keys(DEFAULT_TIMER.inner_timers)
 
 to = TimerOutput()
 @timeit to "sleep" sleep(0.1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TimerOutputs
-using Compat.Test
+using Test
 
 import TimerOutputs: DEFAULT_TIMER, ncalls, flatten,
                      prettytime, prettymemory, prettypercent, prettycount
@@ -96,15 +96,15 @@ end
 
 # test throws
 function foo2(v)
-    timeit(to, "throwing") do
-        sleep(1)
+    @timeit to "throwing" begin
+        sleep(0.01)
         print(v[6]) # OOB
     end
 end
 
 function foo3(v)
-    timeit("throwing") do
-        sleep(1)
+    @timeit "throwing" begin
+        sleep(0.01)
         print(v[6]) # OOB
     end
 end


### PR DESCRIPTION
The new optimizer in Base has support for loading a TimerOutputs-instrumented second copy of itself for performance analysis purposes. Of course the compiler is a bit of an unusual environment. In particular, it has its complete own copy of most basic datatypes and functions, so in order to function correctly, TimerOutputs needs to make sure to use the ones visible in TimerOutputs.jl not the ones in the host module. Additionally this fixed a bug where `continue` in the timed section would break the timing.