### PR TITLE
Add complement function

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,46 @@ julia> print_timer()
 
 The default timer object can be retrieved with `TimerOutputs.get_defaulttimer()`.
 
+## Measuring time consumed outside `@timeit` blocks
+
+Many times operations that we do not consider time consuming turn to be relevant.
+However, adding additional timming blocks just to time initializations and other
+less important calls is annoying.
+
+The `TimerOutputs.complement!()` function can be used to modify a timer and add
+values for complement of timed sections. For instance:
+
+```julia
+to = TimerOutput()
+
+@timeit to "section1" sleep(0.02)
+@timeit to "section2" begin
+    @timeit to "section2" sleep(0.1)
+    sleep(0.01)
+end
+
+TimerOuputs.complement!(to)
+```
+
+We cna print the result:
+
+```julia
+julia> print_timer(to)
+───────────────────────────────────────────────────────────────────────────
+                                    Time                   Allocations
+                            ──────────────────────   ───────────────────────
+      Tot / % measured:          186ms / 81.3%           3.00MiB / 0.05%
+
+ Section            ncalls     time   %tot     avg     alloc   %tot      avg
+ ───────────────────────────────────────────────────────────────────────────
+ section2                1    127ms  84.0%   127ms   1.28KiB  85.4%  1.28KiB
+   section2.1            1    110ms  72.3%   110ms         -  14.6%        -
+   Extra section2        1   17.7ms  11.7%  17.7ms   1.06KiB  70.8%  1.06KiB
+ section1                1   24.3ms  16.0%  24.3ms         -  14.6%        -
+ ───────────────────────────────────────────────────────────────────────────
+```
+
+In order to complement the default timer simply call `TimerOuputs.complement!()`.
 
 ## Overhead
 

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -251,7 +251,8 @@ function _flatten!(to::TimerOutput, inner_timers::Dict{String,TimerOutput})
     end
 end
 
-function complement(to::TimerOutput)
+complement!() = complement!(DEFAULT_TIMER)
+function complement!(to::TimerOutput)
     if length(to.inner_timers) == 0
         return nothing
     end
@@ -260,7 +261,7 @@ function complement(to::TimerOutput)
     for timer in values(to.inner_timers)
         tot_time -= timer.accumulated_data.time
         tot_allocs -= timer.accumulated_data.allocs
-        complement(timer)
+        complement!(timer)
     end
     tot_time = max(tot_time, 0)
     tot_allocs = max(tot_allocs, 0)
@@ -269,6 +270,6 @@ function complement(to::TimerOutput)
         timer = TimerOutput(to.start_data, TimeData(max(1,to.accumulated_data.ncalls), tot_time, tot_allocs), Dict{String,TimerOutput}(), TimerOutput[], name, false, (tot_time, tot_allocs), to.name, to)
         to.inner_timers[name] = timer
     end
-    return nothing
+    return to
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,4 +262,16 @@ end
 continue_test()
 @test isempty(to_continue.inner_timers["x"].inner_timers["test"].inner_timers)
 
+
+to = TimerOutput()
+@timeit to "section1" sleep(0.02)
+@timeit to "section2" begin
+    @timeit to "section2.1" sleep(0.1)
+    sleep(0.01)
+end
+TimerOutputs.complement!(to)
+
+tom = flatten(to)
+@test ncalls(tom["Extra section2"]) == 1
+
 end # testset


### PR DESCRIPTION
This function was very useful for figuring out slowness in non timed areas of code like initializations and finalizations.

I used to write `Extra` blocks explicitly, which was a mess in the code with a bunch of `begin .. end` blocks everywhere.

This function modifies the root timer output by adding the explicit complement of the nested measurements.

usage:

If sections are nested like in the example below:

```julia
to = TimerOutput()

@timeit to "nest 1" begin
    sleep(0.1)
    @timeit to "level 2.1" sleep(0.1)
    for i in 1:20; @timeit to "level 2.2" sleep(0.02); end
end
@timeit to "nest 2" begin
    for i in 1:30; @timeit to "level 2.1" sleep(0.01); end
    @timeit to "level 2.2" sleep(0.1)
end
```

the table is displayed as:

```julia
julia> TimerOutputs.complement(to)
julia> show(to, allocations = false, compact = true)
 ────────────────────────────────────
 Section          ncalls     time   %tot
 ────────────────────────────────────
 nest 1                 1    669ms  60.5%
   level 2.2            20    423ms  38.3%
   Extra nest 1       1    145ms  13.05%
   level 2.1             1    101ms  9.15%
 nest 2                  1    437ms  39.5%
   level 2.1           30    335ms  30.3%
   level 2.2             1    101ms  9.16%
   Extra nest 2        1        1ms   0.04%
 ────────────────────────────────────
```