### PR TITLE
Add `@timeit_debug` and friends for zero-overhead timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,23 +297,12 @@ The default timer object can be retrieved with `TimerOutputs.get_defaulttimer()`
 There is a small overhead in timing a section (0.25 μs) which means that this package is not suitable for measuring sections that finish very quickly.
 For proper benchmarking you want to use a more suitable tool like [*BenchmarkTools*](https://github.com/JuliaCI/BenchmarkTools.jl).
 
-It is sometimes desireable to be able "turn on and off" the `@timeit` macro.
-There is, however, no simple way to redefine how `@timeit` should work after precompilation.
-A simple solution is to define your own macro (here `@mytimeit`) that works exactly the same as `@timeit` except it can be enabled / disabled at will:
-
-```jl
-ENABLE_TIMINGS = false
-
-macro mytimeit(exprs...)
-    if ENABLE_TIMINGS
-        return :(@timeit($(esc.(exprs)...)))
-    else
-        return esc(exprs[end])
-    end
-end
-```
-
-This will create a macro that "does nothing" (just returns the expression) depending on the value of `ENABLE_TIMINGS` when the macro is expanded.
+It is sometimes desireable to be able "turn on and off" the `@timeit` macro, for instance you may wish to instrument a package with `@timeit` macros, but then not deal with the overhead of the timings during normal package operation.
+To enable this, we provide the `@timeit_debug` macro, which wraps the `@timeit` macro with a conditional, checking if debug timings have been enabled.
+Because you may wish to turn on only certain portions of your instrumented code base (or multiple codebases may have instrumented their code), debug timings are enabled on a module-by-module basis.
+By default, debug timings are disabled, and this conditional should be optimized away, allowing for truly zero-overhead.
+If a user calls `TimerOutputs.enable_debug_timings(<module>)`, the `<module>.timeit_debug_enabled()` method will be redefined, causing all dependent methods to be recompiled within that module.
+This may take a while, and hence is intended only for debugging usage, however all calls to `@timeit_debug` (within that Module) will thereafter be enabled.
 
 ## Author
 

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -126,10 +126,14 @@ macro timeit_debug(args...)
 end
 
 function enable_debug_timings(m::Module)
-    Core.eval(m, :(timeit_debug_enabled() = true))
+    if !getfield(m, :timeit_debug_enabled)()
+        Core.eval(m, :(timeit_debug_enabled() = true))
+    end
 end
 function disable_debug_timings(m::Module)
-    Core.eval(m, :(timeit_debug_enabled() = false))
+    if getfield(m, :timeit_debug_enabled)()
+        Core.eval(m, :(timeit_debug_enabled() = false))
+    end
 end
 
 timer_expr(args...) = throw(ArgumentError("invalid macro usage for @timeit, use as @timeit [to] label codeblock"))

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -114,7 +114,7 @@ Base.@deprecate get_defaultimer get_defaulttimer
 
 # Macro
 macro timeit(args...)
-    return timer_expr(args...)
+    return timer_expr(__module__, false, args...)
 end
 
 macro timeit_debug(args...)
@@ -122,13 +122,7 @@ macro timeit_debug(args...)
         Core.eval(__module__, :(timeit_debug_enabled() = false))
     end
 
-    quote
-        if $(__module__).timeit_debug_enabled()
-            $(timer_expr(args...))
-        else
-            $(esc(args[end]))
-        end
-    end
+    return timer_expr(__module__, true, args...)
 end
 
 function enable_debug_timings(m::Module)
@@ -148,17 +142,17 @@ function is_func_def(f)
     end
 end
 
-function timer_expr(ex::Expr)
-    is_func_def(ex) && return timer_expr_func(:(TimerOutputs.DEFAULT_TIMER), ex)
-    return timer_expr(:(TimerOutputs.DEFAULT_TIMER), ex)
+function timer_expr(m::Module, is_debug::Bool, ex::Expr)
+    is_func_def(ex) && return timer_expr_func(m, is_debug, :(TimerOutputs.DEFAULT_TIMER), ex)
+    return timer_expr(m, is_debug, :(TimerOutputs.DEFAULT_TIMER), ex)
 end
 
-function timer_expr(label_or_to, ex::Expr)
-    is_func_def(ex) && return timer_expr_func(label_or_to, ex)
-    return timer_expr(:(TimerOutputs.DEFAULT_TIMER), label_or_to, ex)
+function timer_expr(m::Module, is_debug::Bool, label_or_to, ex::Expr)
+    is_func_def(ex) && return timer_expr_func(m, is_debug, label_or_to, ex)
+    return timer_expr(m, is_debug, :(TimerOutputs.DEFAULT_TIMER), label_or_to, ex)
 end
 
-function timer_expr_func(to, expr::Expr)
+function timer_expr_func(m::Module, is_debug::Bool, to, expr::Expr)
     if expr.args[1].head == :where
         wheres = expr.args[1].args[2:end]
         declaration = expr.args[1].args[1]
@@ -176,11 +170,28 @@ function timer_expr_func(to, expr::Expr)
         args     = declaration.args[2:end]
     end
     body = expr.args[2]
-    return quote
-        function $(esc(funcname))($([esc(arg) for arg in args]...))::$(esc(T)) where {$([esc(wher) for wher in wheres]...)}
-            $(timeit)($(esc(to)), $(string(funcname))) do
+
+    timeit_block = quote
+        $(timeit)($(esc(to)), $(string(funcname))) do
+            $(esc(body))
+        end
+    end
+
+    # If this is a `@timeit_debug`, then we insert the bypass conditional into our timeit_block
+    if is_debug
+        timeit_block = quote
+            if $(esc(m)).timeit_debug_enabled()
+                $(timeit_block)
+            else
                 $(esc(body))
             end
+        end
+    end
+
+
+    return quote
+        function $(esc(funcname))($([esc(arg) for arg in args]...))::$(esc(T)) where {$([esc(wher) for wher in wheres]...)}
+            $(timeit_block)
         end
     end
 end
@@ -192,8 +203,8 @@ function do_accumulate!(accumulated_data, t₀, b₀)
 end
 
 
-function timer_expr(to::Union{Symbol,Expr}, label, ex::Expr)
-    quote
+function timer_expr(m::Module, is_debug::Bool, to::Union{Symbol,Expr}, label, ex::Expr)
+    timeit_block = quote
         local accumulated_data = $(push!)($(esc(to)), $(esc(label)))
         local b₀ = $(gc_bytes)()
         local t₀ = $(time_ns)()
@@ -205,6 +216,18 @@ function timer_expr(to::Union{Symbol,Expr}, label, ex::Expr)
                 $(pop!)($(esc(to)))
             end))
         val
+    end
+
+    if is_debug
+        return quote
+            if $(esc(m)).timeit_debug_enabled()
+                $(timeit_block)
+            else
+                $(esc(ex))
+            end
+        end
+    else
+        return timeit_block
     end
 end
 

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -117,6 +117,27 @@ macro timeit(args...)
     return timer_expr(args...)
 end
 
+macro timeit_debug(args...)
+    if !isdefined(__module__, :timeit_debug_enabled)
+        Core.eval(__module__, :(timeit_debug_enabled() = false))
+    end
+
+    quote
+        if $(__module__).timeit_debug_enabled()
+            $(timer_expr(args...))
+        else
+            $(esc(args[end]))
+        end
+    end
+end
+
+function enable_debug_timings(m::Module)
+    Core.eval(m, :(timeit_debug_enabled() = true))
+end
+function disable_debug_timings(m::Module)
+    Core.eval(m, :(timeit_debug_enabled() = false))
+end
+
 timer_expr(args...) = throw(ArgumentError("invalid macro usage for @timeit, use as @timeit [to] label codeblock"))
 
 function is_func_def(f)

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -3,7 +3,7 @@ __precompile__()
 module TimerOutputs
 
 import Base: show, time_ns, gc_bytes
-export TimerOutput, @timeit, reset_timer!, print_timer, timeit
+export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit
 
 using Crayons
 using Printf

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,4 +286,22 @@ TimerOutputs.enable_debug_timings(Main)
 debug_test()
 @test "sleep" in keys(to_debug.inner_timers)
 
+
+# Test functional-form @timeit_debug with @eval'ed functions
+to_debug = TimerOutput()
+
+@timeit_debug to_debug function baz(x, y)
+    @timeit_debug to_debug "sleep" sleep(0.001)
+    return x + y * x
+end
+
+TimerOutputs.disable_debug_timings(Main)
+baz(1, 2.0)
+@test isempty(to_debug.inner_timers)
+
+TimerOutputs.enable_debug_timings(Main)
+baz(1, 2.0)
+@test "baz" in keys(to_debug.inner_timers)
+@test "sleep" in keys(to_debug.inner_timers["baz"].inner_timers)
+
 end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,4 +272,18 @@ end
 continue_test()
 @test isempty(to_continue.inner_timers["x"].inner_timers["test"].inner_timers)
 
+
+# Test @timeit_debug
+to_debug = TimerOutput()
+function debug_test()
+    @timeit_debug to_debug "sleep" sleep(0.001)
+end
+
+TimerOutputs.disable_debug_timings(Main)
+debug_test()
+@test !("sleep" in keys(to_debug.inner_timers))
+TimerOutputs.enable_debug_timings(Main)
+debug_test()
+@test "sleep" in keys(to_debug.inner_timers)
+
 end # testset


### PR DESCRIPTION
Example usage:
```
using TimerOutputs
to = TimerOutput()

function foo()
   global to
   @timeit_debug to "sleepytime" println("hello")
   display(to)
   return nothing
end

@info "With debug timings disabled:"
TimerOutputs.disable_debug_timings()
foo()

@info "With debug timings enabled:"
TimerOutputs.enable_debug_timings()
foo()
```