### PR TITLE
Fix call to Base.gc_bytes (fixes #67).

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -1,9 +1,18 @@
-__precompile__()
-
 module TimerOutputs
 
-import Base: show, time_ns, gc_bytes
+import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit
+
+# https://github.com/JuliaLang/julia/pull/33717
+if VERSION < v"1.4.0-DEV.475"
+    gc_bytes() = Base.gc_bytes()
+else
+    function gc_bytes()
+        b = Ref{Int64}(0)
+        Base.gc_bytes(b)
+        return b[]
+    end
+end
 
 using Printf
 


### PR DESCRIPTION
- Fix call to Base.gc_bytes (fixes #67).
- Remote `__precompile__`.
- Set version to 0.5.3.