### PR TITLE
fix usage of default timer when TimerOutputs symbol is not available

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -157,13 +157,13 @@ function is_func_def(f)
 end
 
 function timer_expr(m::Module, is_debug::Bool, ex::Expr)
-    is_func_def(ex) && return timer_expr_func(m, is_debug, :(TimerOutputs.DEFAULT_TIMER), ex)
-    return timer_expr(m, is_debug, :(TimerOutputs.DEFAULT_TIMER), ex)
+    is_func_def(ex) && return timer_expr_func(m, is_debug, :($(TimerOutputs.DEFAULT_TIMER)), ex)
+    return timer_expr(m, is_debug, :($(TimerOutputs.DEFAULT_TIMER)), ex)
 end
 
 function timer_expr(m::Module, is_debug::Bool, label_or_to, ex::Expr)
     is_func_def(ex) && return timer_expr_func(m, is_debug, label_or_to, ex)
-    return timer_expr(m, is_debug, :(TimerOutputs.DEFAULT_TIMER), label_or_to, ex)
+    return timer_expr(m, is_debug, :($(TimerOutputs.DEFAULT_TIMER)), label_or_to, ex)
 end
 
 function timer_expr_func(m::Module, is_debug::Bool, to, expr::Expr)
@@ -215,7 +215,7 @@ function do_accumulate!(accumulated_data, t₀, b₀)
     accumulated_data.ncalls += 1
 end
 
-function timer_expr(m::Module, is_debug::Bool, to::Union{Symbol,Expr}, label, ex::Expr)
+function timer_expr(m::Module, is_debug::Bool, to::Union{Symbol, Expr, TimerOutput}, label, ex::Expr)
     timeit_block = quote
         local accumulated_data = $(push!)($(esc(to)), $(esc(label)))
         local b₀ = $(gc_bytes)()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,6 +331,16 @@ end
     @test TimerOutputs.ncalls(sim.timer["step2!"]) == 2
 end
 
+# default timer without explicitly loading TimerOutputs
+TimerOutputs.reset_timer!()
+module TestModule
+    using TimerOutputs: @timeit
+    foo(x) = x
+    @timeit "foo" foo(1)
+end
+@test "foo" in keys(DEFAULT_TIMER.inner_timers)
+TimerOutputs.reset_timer!()
+
 # Broken
 #=
 # Type inference with @timeit_debug
@@ -367,29 +377,29 @@ TimerOutputs.disable_debug_timings(@__MODULE__)
                     end
                 end
                 @timeit timer "depth1b" begin
-                    
+
                 end
             end
         end
         ret
     end
-    
+
     to = TimerOutput()
     doit(to, 1)
     a0 = TimerOutputs.allocated(to["depth0"])
     a1 = TimerOutputs.allocated(to["depth0"]["depth1"])
     a2 = TimerOutputs.allocated(to["depth0"]["depth1"]["depth2"])
-    
+
     to = TimerOutput()
     doit(to, 100000)
-    
+
     to0 = to["depth0"]
     to1 = to0["depth1"]
     to1b = to0["depth1b"]
     to2 = to1["depth2"]
     to2b = to1["depth2b"]
-    
-    # test that leaf timers add zero allocations 
+
+    # test that leaf timers add zero allocations
     # and other timers only add allocations once
     @test TimerOutputs.allocated(to0) == a0
     @test TimerOutputs.allocated(to1) == a1


### PR DESCRIPTION
Fixes #78 