### PR TITLE
improve alignment

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -96,7 +96,7 @@ function totmeasured(to::TimerOutput)
 end
 
 function longest_name(to::TimerOutput, indent = 0)
-    m = length(to.name) + indent
+    m = textwidth(to.name) + indent
     for inner_timer in values(to.inner_timers)
         m = max(m, longest_name(inner_timer, indent + 2))
     end

--- a/src/show.jl
+++ b/src/show.jl
@@ -51,7 +51,7 @@ end
 
 # truncate string and add dots
 function truncdots(str, n)
-    length(str) <= n && return str
+    textwidth(str) <= n && return str
     n <= 3 && return ""
     io = IOBuffer()
     for (i, c) in enumerate(str)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -83,3 +83,17 @@ function prettycount(t::Integer)
     end
     return str
 end
+
+function rpad(
+    s::Union{AbstractChar,AbstractString},
+    n::Integer,
+    p::Union{AbstractChar,AbstractString}=' ',
+) :: String
+    n = Int(n)::Int
+    m = signed(n) - Int(textwidth(s))::Int
+    m ≤ 0 && return string(s)
+    l = textwidth(p)
+    q, r = divrem(m, l)
+    r == 0 ? string(s, p^q) : string(s, p^q, first(p, r))
+end
+


### PR DESCRIPTION
Fixes https://github.com/KristofferC/TimerOutputs.jl/issues/94:

```
 ───────────────────────────────────────────────────────────────────
                            Time                   Allocations
                    ──────────────────────   ───────────────────────
  Tot / % measured:      11.2s / 87.7%           42.7MiB / 0.46%

 Section    ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────
 ⟨k|H₁|k̃⟩      200    4.74s  48.4%  23.7ms   73.2KiB  36.0%     375B
 ⟨k|H₁|k⟩      200    2.53s  25.9%  12.6ms   65.0KiB  32.0%     333B
 ⟨k̃|H₁|k̃⟩      200    2.52s  25.8%  12.6ms   65.0KiB  32.0%     333B
 ───────────────────────────────────────────────────────────────────
```

Problem was that `Base.rpad` does not look at `textwidth` but at `length`. Not sure that is the best choice... Anyway, we can just roll our own that does `textwidth`.