### PR TITLE
Use ExprTools, reuse _timer_expr, rework timeit_debug func def.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 julia = "1"
+ExprTools = "0.1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 version = "0.5.8"
 
 [deps]
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -1,5 +1,7 @@
 module TimerOutputs
 
+using ExprTools
+
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,
                     enable_timer!, disable_timer!, @notimeit

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,3 +460,11 @@ end
     @test ncalls(to["ff1"]) == 3
 end
 
+# Type inference with @timeit_debug
+@timeit_debug function make_zeros()
+   dims = (3, 4)
+   zeros(dims)
+end
+@inferred make_zeros()
+TimerOutputs.enable_debug_timings(@__MODULE__)
+@inferred make_zeros()


### PR DESCRIPTION
In order to add a feature, I wanted to facilitate code reuse between `timer_expr` and `timer_expr_func`. That prompted me to use ExprTools to simplify the implementation, which surfaced a bug similar to https://github.com/KristofferC/TimerOutputs.jl/issues/65#issuecomment-553807491. Since I wanted to keep the code reuse, I decided to implement https://github.com/KristofferC/TimerOutputs.jl/issues/61#issuecomment-628617136.

Fixes https://github.com/KristofferC/TimerOutputs.jl/issues/61