### PR TITLE
Use FastClosures to ensure no boxes are created.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,12 @@ version = "0.5.9"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-julia = "1"
 ExprTools = "0.1.0"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -2,6 +2,8 @@ module TimerOutputs
 
 using ExprTools
 
+using FastClosures
+
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,
                     enable_timer!, disable_timer!, @notimeit


### PR DESCRIPTION
I had hoped this would help https://github.com/KristofferC/TimerOutputs.jl/issues/120, but it doesn't seem to matter.