### PR TITLE
Add option to control maximum level to print in nested timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The `print_timer([io::IO = stdout], to::TimerOutput, kwargs)`, (or `show`) takes
 * `sortby::Symbol` ─ sort the sections according to `:time` (default), `:ncalls`, `:allocations` or `:name`
 * `linechars::Symbol` ─ use either `:unicode` (default) or `:ascii` to draw the horizontal lines in the table
 * `compact::Bool` ─ hide the `avg` column (default `false`)
+* `maxlevel::Integer` ─ maximum level of nested function calls printed (default `100`)
 
 ## Flattening
 


### PR DESCRIPTION
Hi,

This PR adds a keyword argument `maxlevel` to `show` that limits the number of nesting levels to print in the output.

Usage:
```julia
using TimerOutputs

to = TimerOutput()

@timeit to "f1" function f1()
    f2(); f2()
end

@timeit to "f2" function f2()
    f3(); f3()
end

@timeit to "f3" function f3()
    sleep(0.1)
end

reset_timer!(to)
f1()
print_timer(to)
print_timer(to, maxlevel=1)
print_timer(to, maxlevel=2)
print_timer(to, maxlevel=3)
```

```julia
julia> print_timer(to)
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations      
                   ──────────────────────   ───────────────────────
 Tot / % measured:      750ms / 57.3%           9.25MiB / 5.27%    

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 f1             1    430ms   100%   430ms    499KiB  100%    499KiB
   f2           2    430ms   100%   215ms    498KiB  100%    249KiB
     f3         4    416ms  96.9%   104ms   8.91KiB  1.78%  2.23KiB
 ──────────────────────────────────────────────────────────────────

julia> print_timer(to, maxlevel=1)
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations      
                   ──────────────────────   ───────────────────────
 Tot / % measured:      817ms / 52.6%           11.7MiB / 4.15%    

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 f1             1    430ms   100%   430ms    499KiB  100%    499KiB
 ──────────────────────────────────────────────────────────────────

julia> print_timer(to, maxlevel=2)
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations      
                   ──────────────────────   ───────────────────────
 Tot / % measured:      819ms / 52.4%           11.8MiB / 4.13%    

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 f1             1    430ms   100%   430ms    499KiB  100%    499KiB
   f2           2    430ms   100%   215ms    498KiB  100%    249KiB
 ──────────────────────────────────────────────────────────────────

julia> print_timer(to, maxlevel=3)
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations      
                   ──────────────────────   ───────────────────────
 Tot / % measured:      3.15s / 13.6%           11.8MiB / 4.12%    

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 f1             1    430ms   100%   430ms    499KiB  100%    499KiB
   f2           2    430ms   100%   215ms    498KiB  100%    249KiB
     f3         4    416ms  96.9%   104ms   8.91KiB  1.78%  2.23KiB
 ──────────────────────────────────────────────────────────────────
```