### PR TITLE
Allow custom merge points

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,4 +17,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@latest
+        env:
+          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ julia> show(merge(to1, to2); compact=true, allocations=false)
  ────────────────────────────────
 ```
 
-Merging can be used to test simple multi-threaded setups, by using thread-local
-`TimerOutput` objects and merging with custom merge points via the `tree_point` arg, which
-should be a vector of string keys to navigate to the merge point. `merge!` is thread-safe
-via a lock, so its use should be minimized for performance.
+Merging can be used to facilitate timing coverage throughout simple multi-threaded setups.
+For instance, use thread-local `TimerOutput` objects that are merged at custom merge points
+via the `tree_point` keyword arg, which is a vector of label strings used to navigate to
+the merge point in the timing tree. `merge!` is thread-safe via a lock.
 
 ```julia
 julia> using TimerOutputs

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -105,10 +105,14 @@ end
 
 # merging timer outputs
 Base.merge(others::TimerOutput...) = merge!(TimerOutput(), others...)
-function Base.merge!(self::TimerOutput, others::TimerOutput...)
+function Base.merge!(self::TimerOutput, others::TimerOutput...; tree_point = String[])
     for other in others
         self.accumulated_data += other.accumulated_data
-        _merge(self.inner_timers, other.inner_timers)
+        it = self.inner_timers
+        for point in tree_point
+            it = it[point].inner_timers
+        end
+        _merge(it, other.inner_timers)
     end
     return self
 end

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -112,11 +112,11 @@ function Base.merge!(self::TimerOutput, others::TimerOutput...; tree_point = Str
     lock(merge_lock) do
         for other in others
             self.accumulated_data += other.accumulated_data
-            it = self.inner_timers
+            its = self.inner_timers
             for point in tree_point
-                it = it[point].inner_timers
+                its = its[point].inner_timers
             end
-            _merge(it, other.inner_timers)
+            _merge(its, other.inner_timers)
         end
         return self
     end

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -114,6 +114,7 @@ function Base.merge!(self::TimerOutput, others::TimerOutput...; tree_point = Str
             self.accumulated_data += other.accumulated_data
             its = self.inner_timers
             for point in tree_point
+                its[point].accumulated_data += other.accumulated_data # add accumulated data to the parents too
                 its = its[point].inner_timers
             end
             _merge(its, other.inner_timers)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -511,3 +511,83 @@ TimerOutputs.enable_debug_timings(@__MODULE__)
         @test ncalls(subto["baz"]) == 2
     end
 end
+
+@testset "merge at custom points during multithreading" begin
+    to = TimerOutput()
+    @timeit to "1" begin
+        @timeit to "1.1" sleep(0.1)
+        @timeit to "1.2" sleep(0.1)
+        @timeit to "1.3" sleep(0.1)
+    end
+
+    @sync begin
+        @timeit to "2" Threads.@spawn begin
+            to2 = TimerOutput()
+            @timeit to2 "2.1" sleep(0.1)
+            @timeit to2 "2.2" sleep(0.1)
+            @timeit to2 "2.3" sleep(0.1)
+            merge!(to, to2, tree_point = ["2"])
+        end
+
+        @timeit to "3" Threads.@spawn begin
+            to3 = TimerOutput()
+            @sync begin
+                @timeit to3 "3.1" Threads.@spawn begin
+                    to31 = TimerOutput()
+                    @timeit to31 "3.1.1" sleep(0.1)
+                    @timeit to31 "3.1.2" sleep(0.1)
+                    @timeit to31 "3.1.3" sleep(0.1)
+                    merge!(to3, to31, tree_point = ["3.1"])
+                end
+                @timeit to3 "3.2" Threads.@spawn begin
+                    to32 = TimerOutput()
+                    @timeit to32 "3.2.1" sleep(0.1)
+                    @timeit to32 "3.2.2" sleep(0.1)
+                    @timeit to32 "3.2.3" sleep(0.1)
+                    merge!(to3, to32, tree_point = ["3.2"])
+                end
+            end
+            merge!(to, to3, tree_point = ["3"])
+        end
+    end
+
+    @test "1" in collect(keys(to.inner_timers))
+    @test ncalls(to.inner_timers["1"]) == 1
+    @test "2" in collect(keys(to.inner_timers))
+    @test ncalls(to.inner_timers["2"]) == 1
+    @test "3" in collect(keys(to.inner_timers))
+    @test ncalls(to.inner_timers["3"]) == 1
+    @test !in("1.1", collect(keys(to.inner_timers)))
+    @test !in("2.1", collect(keys(to.inner_timers)))
+    @test !in("3.1", collect(keys(to.inner_timers)))
+    @test !in("3.1.1", collect(keys(to.inner_timers)))
+    @test !in("3.2", collect(keys(to.inner_timers)))
+    @test !in("3.2.1", collect(keys(to.inner_timers)))
+
+    to1 = to.inner_timers["1"]
+    @test "1.1" in collect(keys(to1.inner_timers))
+    @test ncalls(to1.inner_timers["1.1"]) == 1
+
+    to2 = to.inner_timers["2"]
+    @test "2.1" in collect(keys(to2.inner_timers))
+    @test ncalls(to2.inner_timers["2.1"]) == 1
+    @test !in("3.1", collect(keys(to2.inner_timers)))
+
+    to3 = to.inner_timers["3"]
+    @test "3.1" in collect(keys(to3.inner_timers))
+    @test ncalls(to3.inner_timers["3.1"]) == 1
+    @test "3.2" in collect(keys(to3.inner_timers))
+    @test ncalls(to3.inner_timers["3.2"]) == 1
+    @test !in("2.1", collect(keys(to3.inner_timers)))
+
+    to31 = to3.inner_timers["3.1"]
+    @test "3.1.1" in collect(keys(to31.inner_timers))
+    @test ncalls(to31.inner_timers["3.1.1"]) == 1
+    @test !in("3.2.1", collect(keys(to31.inner_timers)))
+
+    to32 = to3.inner_timers["3.2"]
+    @test "3.2.1" in collect(keys(to32.inner_timers))
+    @test ncalls(to32.inner_timers["3.2.1"]) == 1
+    @test !in("3.1.1", collect(keys(to32.inner_timers)))
+
+end


### PR DESCRIPTION
One way to handle multithreading seems to be to use local TimerOutput objects, but currently `merge!` just globally merges. 
This allows merging into a custom point in the destination `to`.

```julia
using TimerOutputs

to = TimerOutput()

@timeit to "1" begin
    @timeit to "1.1" sleep(0.1)
    @timeit to "1.2" sleep(0.1)
    @timeit to "1.3" sleep(0.1)
end

@timeit to "2" Threads.@spawn begin
    to2 = TimerOutput()
    @timeit to2 "2.1" sleep(0.1)
    @timeit to2 "2.2" sleep(0.1)
    @timeit to2 "2.3" sleep(0.1)
    merge!(to, to2, tree_point = ["2"])
end
```
```
julia> to
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations      
                   ──────────────────────   ───────────────────────
 Tot / % measured:      3.23s / 9.79%           13.5MiB / 36.9%    
 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 1              1    309ms  98.0%   309ms   4.55MiB  91.5%  4.55MiB
   1.3          1    106ms  33.6%   106ms      320B  0.01%     320B
   1.2          1    102ms  32.3%   102ms      320B  0.01%     320B
   1.1          1    101ms  32.0%   101ms   4.54MiB  91.4%  4.54MiB
 2              1   6.47ms  2.05%  6.47ms    435KiB  8.54%   435KiB
   2.2          1    106ms  33.6%   106ms      480B  0.01%     480B
   2.3          1    105ms  33.4%   105ms      144B  0.00%     144B
   2.1          1    103ms  32.5%   103ms   5.03MiB  101%   5.03MiB
 ──────────────────────────────────────────────────────────────────
 ```

otherwise, currently a `merge!(to, to2)` would result in
```
julia> to
 ──────────────────────────────────────────────────────────────────
                           Time                   Allocations      
                   ──────────────────────   ───────────────────────
 Tot / % measured:      1.86s / 33.8%           1.61MiB / 0.65%    

 Section   ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────
 1              1    315ms  50.2%   315ms   4.02KiB  37.2%  4.02KiB
   1.2          1    106ms  16.9%   106ms      320B  2.90%     320B
   1.1          1    105ms  16.8%   105ms      320B  2.90%     320B
   1.3          1    103ms  16.5%   103ms      320B  2.90%     320B
 2.1            1    105ms  16.8%   105ms      144B  1.30%     144B
 2.2            1    105ms  16.8%   105ms      144B  1.30%     144B
 2.3            1    102ms  16.2%   102ms      144B  1.30%     144B
 2              1    134μs  0.02%   134μs   6.35KiB  58.9%  6.35KiB
 ──────────────────────────────────────────────────────────────────
```


I can add tests if this is welcomed