### PR TITLE
Remove erroneous accumulated data addition during merge!

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -116,7 +116,6 @@ function Base.merge!(self::TimerOutput, others::TimerOutput...; tree_point = Str
             self.accumulated_data += other.accumulated_data
             its = self.inner_timers
             for point in tree_point
-                its[point].accumulated_data += other.accumulated_data # add accumulated data to the parents too
                 its = its[point].inner_timers
             end
             _merge(its, other.inner_timers)


### PR DESCRIPTION
This appears to be a design error in #128

Although I don't have a MWE, in real world usage in a threading setup with v0.5.10 I was seeing parents with 0 calls, time & allocations, which is fixed by removing this line.