### PR TITLE
RFC: Allow prev_timer to be set to nothing

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -274,6 +274,7 @@ function reset_timer!(to::TimerOutput)
     to.start_data = TimeData(0, time_ns(), gc_bytes())
     to.accumulated_data = TimeData()
     to.prev_timer_label = ""
+    to.prev_timer = nothing
     resize!(to.timer_stack, 0)
     return to
 end

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -31,15 +31,14 @@ mutable struct TimerOutput
     enabled::Bool
     totmeasured::Tuple{Int64,Int64}
     prev_timer_label::String
-    prev_timer::TimerOutput
+    prev_timer::Union{TimerOutput,Nothing}
 
     function TimerOutput(label::String = "root")
         start_data = TimeData(0, time_ns(), gc_bytes())
         accumulated_data = TimeData()
         inner_timers = Dict{String,TimerOutput}()
         timer_stack = TimerOutput[]
-        timer = new(start_data, accumulated_data, inner_timers, timer_stack, label, false, true, (0, 0), "")
-        timer.prev_timer = timer
+        return new(start_data, accumulated_data, inner_timers, timer_stack, label, false, true, (0, 0), "", nothing)
     end
 
     # Jeez...
@@ -50,7 +49,7 @@ mutable struct TimerOutput
 end
 
 Base.copy(to::TimerOutput) = TimerOutput(copy(to.start_data), copy(to.accumulated_data), copy(to.inner_timers),
-                                         copy(to.timer_stack), to.name, to.flattened, to.enabled, to.totmeasured, "", to)
+                                         copy(to.timer_stack), to.name, to.flattened, to.enabled, to.totmeasured, "", nothing)
 
 const DEFAULT_TIMER = TimerOutput()
 


### PR DESCRIPTION
The circular self-reference of `prev_timer` field can cause problems in some circumstances.
For example, exporting `TimerOutput` using `JLD` causes `StackOverflowError`.
Workaround for #40

I realise this is an issue for `JLD` rather than `TimerOutputs`, so marking as RFC. However, it seems to provide a workaround with little impact on `TimerOutputs`.

Change type of `prev_timer` to `Union{TimerOutput,Nothing}` which allows setting it to `nothing`, breaking the circularity.
It also seems consistent that `prev_timer == nothing` whenever `prev_timer_label == ""`.

Before saving to `JLD`, set `prev_timer` to `nothing`.