### PR TITLE
Add globally registered timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,49 @@ julia> print_timer()
 
 The default timer object can be retrieved with `TimerOutputs.get_defaulttimer()`.
 
+## Shared Timers
+
+It is sometimes desirable for a timer to be shared across all users of the package.
+For this purpose, `get_timer` maintains a collection of named timers defined in the package.
+
+`get_timer(timer_name::String)` retrieves the timer `timer_name` from the collection, creating a new timer if none already exists.
+To avoid errors, these timers should be retrieved in the scope where they are to be used.
+
+Note that this function is not recommended to be used extensively as it is prone to name collisions.
+
+For example:
+```julia
+module UseTimer
+using TimerOutputs: @timeit, get_timer
+
+function foo()
+    to = get_timer("Shared")
+    @timeit to "foo" sleep(0.1)
+end
+end
+
+to = get_timer("Shared")
+@timeit to "section1" begin
+    UseTimer.foo()
+    sleep(0.01)
+end
+```
+
+which prints:
+```julia
+julia> print_timer(get_timer("Shared"))
+ ───────────────────────────────────────────────────────────────────
+                            Time                   Allocations
+                    ──────────────────────   ───────────────────────
+  Tot / % measured:      17.1s / 0.82%           44.0MiB / 2.12%
+
+ Section    ncalls     time   %tot     avg     alloc   %tot      avg
+ ───────────────────────────────────────────────────────────────────
+ section1        1    140ms   100%   140ms    956KiB  100%    956KiB
+   foo           1    102ms  72.7%   102ms      144B  0.01%     144B
+ ───────────────────────────────────────────────────────────────────
+```
+
 ## Measuring time consumed outside `@timeit` blocks
 
 Often, operations that we do not consider time consuming turn out to be relevant.

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -61,16 +61,12 @@ Returns the `TimerOutput` associated with `name`.
 If no timers are associated with `name`, a new `TimerOutput` will be created.
 """
 function get_timer(name::String)
-    if !haskey(_timers, name)
-        lock(merge_lock) do
-            # Double check key in case of race condition
-            if !haskey(_timers, name)
-                _timers[name] = TimerOutput(name)
-            end
+    lock(_timers_lock) do
+        if !haskey(_timers, name)
+            _timers[name] = TimerOutput(name)
         end
+        return _timers[name]
     end
-
-    return _timers[name]
 end
 
 # push! and pop!

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -52,6 +52,21 @@ Base.copy(to::TimerOutput) = TimerOutput(copy(to.start_data), copy(to.accumulate
                                          copy(to.timer_stack), to.name, to.flattened, to.enabled, to.totmeasured, "", nothing)
 
 const DEFAULT_TIMER = TimerOutput()
+const _timers = Dict{String, TimerOutput}("Default" => DEFAULT_TIMER)
+
+"""
+    get_timer(name::String)
+
+Returns the `TimerOutput` associated with `name`.
+If no timers are associated with `name`, a new `TimerOutput` will be created.
+"""
+function get_timer(name::String)
+    if !haskey(_timers, name)
+        _timers[name] = TimerOutput(name)
+    end
+
+    return _timers[name]
+end
 
 # push! and pop!
 function Base.push!(to::TimerOutput, label::String)

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -4,7 +4,7 @@ using ExprTools
 
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,
-                    enable_timer!, disable_timer!, @notimeit
+                    enable_timer!, disable_timer!, @notimeit, get_timer
 
 # https://github.com/JuliaLang/julia/pull/33717
 if VERSION < v"1.4.0-DEV.475"


### PR DESCRIPTION
Closes #134.

Adds `get_timer` function to register and retrieve timers. This allows users to access timers for different workflows without having to pass them through intermediate packages.

Example use case:

```
module ReadOnlyDB

using TimerOutputs

function get_data(...)
     db_timer = get_timer("DBAccess")  # Used in all DB packages
     @timeit db_timer "fetch" ...
end
end
```

```
using Simulation  # uses PkgA which uses PkgB which uses several DB packages
using TimerOutputs
simulate(...)

print_timer(get_timer("DBAccess"))  # keep track of DB efficiency
```