### PR TITLE
add `todict` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,17 @@ version = "0.5.13"
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
-julia = "1"
 ExprTools = "0.1.0"
+JSON3 = "1.9"
+StructTypes = "1.8"
+julia = "1"
 
 [extras]
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "JSON3"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,13 @@ version = "0.5.13"
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
 ExprTools = "0.1.0"
-JSON3 = "1.9"
-StructTypes = "1.8"
 julia = "1"
 
 [extras]
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "JSON3"]
+test = ["Test"]

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -1,6 +1,7 @@
 module TimerOutputs
 
 using ExprTools
+using StructTypes
 
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -1,7 +1,6 @@
 module TimerOutputs
 
 using ExprTools
-using StructTypes
 
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -97,3 +97,20 @@ function rpad(
     r == 0 ? string(s, p^q) : string(s, p^q, first(p, r))
 end
 
+#################
+# Serialization #
+#################
+
+StructTypes.StructType(::Type{TimerOutput}) = StructTypes.DictType()
+StructTypes.keyvaluepairs(to::TimerOutput) = pairs(timer_dict(to))
+
+function timer_dict(to::TimerOutput)
+    return Dict{String,Any}(
+        "n_calls" => ncalls(to),
+        "time_ns" => time(to),
+        "allocated_bytes" => allocated(to),
+        "total_allocated_bytes" => totallocated(to),
+        "total_time_ns" => tottime(to),
+        "inner_timers" => Dict{String, Any}(k => timer_dict(v) for (k,v) in to.inner_timers)
+    )
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -101,16 +101,25 @@ end
 # Serialization #
 #################
 
-StructTypes.StructType(::Type{TimerOutput}) = StructTypes.DictType()
-StructTypes.keyvaluepairs(to::TimerOutput) = pairs(timer_dict(to))
+"""
+    todict(to::TimerOutput) -> Dict{String, Any}
 
-function timer_dict(to::TimerOutput)
+Converts a `TimerOutput` into a nested set of dictionaries, with keys and value types:
+
+* `"n_calls"`: `Int`
+* `"time_ns"`: `Int`
+* `"allocated_bytes"`: `Int`
+* `"total_allocated_bytes"`: `Int`
+* `"total_time_ns"`: `Int`
+* `"inner_timers"`: `Dict{String, Dict{String, Any}}`
+"""
+function todict(to::TimerOutput)
     return Dict{String,Any}(
         "n_calls" => ncalls(to),
         "time_ns" => time(to),
         "allocated_bytes" => allocated(to),
         "total_allocated_bytes" => totallocated(to),
         "total_time_ns" => tottime(to),
-        "inner_timers" => Dict{String, Any}(k => timer_dict(v) for (k,v) in to.inner_timers)
+        "inner_timers" => Dict{String, Any}(k => todict(v) for (k,v) in to.inner_timers)
     )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using TimerOutputs
 using Test
-using JSON3
 
 import TimerOutputs: DEFAULT_TIMER, ncalls, flatten,
-                     prettytime, prettymemory, prettypercent, prettycount
+                     prettytime, prettymemory, prettypercent, prettycount, todict
 
 reset_timer!()
 
@@ -655,18 +654,18 @@ end
     end
     @timeit to "baz" identity(nothing)
 
-    roundtrip = JSON3.read(JSON3.write(to))
 
-    function compare(to, json_object)
-        @test TimerOutputs.tottime(to) == json_object.total_time_ns
-        @test TimerOutputs.ncalls(to) == json_object.n_calls
-        @test TimerOutputs.totallocated(to) == json_object.total_allocated_bytes
-        @test TimerOutputs.allocated(to) == json_object.allocated_bytes
-        @test TimerOutputs.time(to) == json_object.time_ns
-        for ((k1, timer), (k2, obj)) in zip(to.inner_timers, json_object.inner_timers)
-            @test k1 == string(k2)
+    function compare(to, d)
+        @test TimerOutputs.tottime(to) == d["total_time_ns"]
+        @test TimerOutputs.ncalls(to) == d["n_calls"]
+        @test TimerOutputs.totallocated(to) == d["total_allocated_bytes"]
+        @test TimerOutputs.allocated(to) == d["allocated_bytes"]
+        @test TimerOutputs.time(to) == d["time_ns"]
+        for ((k1, timer), (k2, obj)) in zip(to.inner_timers, d["inner_timers"])
+            @test k1 == k2
             compare(timer, obj)
         end
     end
-    compare(to, roundtrip)
+    
+    compare(to, todict(to))
 end


### PR DESCRIPTION
This allows serialization with JSON3:

```julia
julia> to
 ──────────────────────────────────────────────────────────────────────
                               Time                   Allocations      
                       ──────────────────────   ───────────────────────
   Tot / % measured:         222s / 0.52%           1.19GiB / 0.04%    

 Section       ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────
 nest 2             1    705ms  61.6%   705ms   2.09KiB  0.42%  2.09KiB
   level 2.2        1    401ms  35.1%   401ms      176B  0.03%     176B
   level 2.1        1    303ms  26.5%   303ms      176B  0.03%     176B
 nest 1             1    439ms  38.4%   439ms    498KiB  100%    498KiB
   level 2.2        1    207ms  18.1%   207ms      176B  0.03%     176B
   level 2.1        3    117ms  10.3%  39.2ms   8.73KiB  1.75%  2.91KiB
 ──────────────────────────────────────────────────────────────────────

julia> JSON3.write(to)
"{\"total_time_ns\":1144369999,\"total_allocated_bytes\":512511,\"time_ns\":0,\"n_calls\":0,\"allocated_bytes\":0,\"inner_timers\":{\"nest 1\":{\"total_time_ns\":324575583,\"total_allocated_bytes\":9120,\"time_ns\":439140583,\"n_calls\":1,\"allocated_bytes\":510367,\"inner_timers\":{\"level 2.1\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":117488250,\"n_calls\":3,\"allocated_bytes\":8944,\"inner_timers\":{}},\"level 2.2\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":207087333,\"n_calls\":1,\"allocated_bytes\":176,\"inner_timers\":{}}}},\"nest 2\":{\"total_time_ns\":704607667,\"total_allocated_bytes\":352,\"time_ns\":705229416,\"n_calls\":1,\"allocated_bytes\":2144,\"inner_timers\":{\"level 2.1\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":303114542,\"n_calls\":1,\"allocated_bytes\":176,\"inner_timers\":{}},\"level 2.2\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":401493125,\"n_calls\":1,\"allocated_bytes\":176,\"inner_timers\":{}}}}}}"

julia> JSON3.pretty(to)
{
           "total_time_ns": 1144369999,
   "total_allocated_bytes": 512511,
                 "time_ns": 0,
                 "n_calls": 0,
         "allocated_bytes": 0,
            "inner_timers": {
                               "nest 1": {
                                                    "total_time_ns": 324575583,
                                            "total_allocated_bytes": 9120,
                                                          "time_ns": 439140583,
                                                          "n_calls": 1,
                                                  "allocated_bytes": 510367,
                                                     "inner_timers": {
                                                                        "level 2.1": {
                                                                                                "total_time_ns": 0,
                                                                                        "total_allocated_bytes": 0,
                                                                                                      "time_ns": 117488250,
                                                                                                      "n_calls": 3,
                                                                                              "allocated_bytes": 8944,
                                                                                                 "inner_timers": {}
                                                                                     },
                                                                        "level 2.2": {
                                                                                                "total_time_ns": 0,
                                                                                        "total_allocated_bytes": 0,
                                                                                                      "time_ns": 207087333,
                                                                                                      "n_calls": 1,
                                                                                              "allocated_bytes": 176,
                                                                                                 "inner_timers": {}
                                                                                     }
                                                                     }
                                         },
                               "nest 2": {
                                                    "total_time_ns": 704607667,
                                            "total_allocated_bytes": 352,
                                                          "time_ns": 705229416,
                                                          "n_calls": 1,
                                                  "allocated_bytes": 2144,
                                                     "inner_timers": {
                                                                        "level 2.1": {
                                                                                                "total_time_ns": 0,
                                                                                        "total_allocated_bytes": 0,
                                                                                                      "time_ns": 303114542,
                                                                                                      "n_calls": 1,
                                                                                              "allocated_bytes": 176,
                                                                                                 "inner_timers": {}
                                                                                     },
                                                                        "level 2.2": {
                                                                                                "total_time_ns": 0,
                                                                                        "total_allocated_bytes": 0,
                                                                                                      "time_ns": 401493125,
                                                                                                      "n_calls": 1,
                                                                                              "allocated_bytes": 176,
                                                                                                 "inner_timers": {}
                                                                                     }
                                                                     }
                                         }
                            }
}
```
This is not enough to be able to de-serialize back into a TimerOutput object, but for my purposes (logging out timers), it's sufficient.