### PR TITLE
Add `TimerOutputs.todict` to README

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.13"
+version = "0.5.14"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/README.md
+++ b/README.md
@@ -145,34 +145,6 @@ The `print_timer([io::IO = stdout], to::TimerOutput, kwargs)`, (or `show`) takes
 * `linechars::Symbol` ─ use either `:unicode` (default) or `:ascii` to draw the horizontal lines in the table
 * `compact::Bool` ─ hide the `avg` column (default `false`)
 
-## Serialization
-
-Timers may be converted to a nested set of dictionaries with the (unexported) `TimerOutputs.todict` function. This can be used to serialize a timer as JSON, for example.
-
-```julia
-julia> to = TimerOutput();
-
-julia> @timeit to "nest 1" begin
-           sleep(0.1)
-           @timeit to "level 2.1" sleep(0.1)
-           for i in 1:20; @timeit to "level 2.2" sleep(0.02); end
-       end
-
-julia> TimerOutputs.todict(to)
-Dict{String, Any} with 6 entries:
-  "total_time_ns" => 726721166
-  "total_allocated_bytes" => 474662
-  "time_ns" => 0
-  "n_calls" => 0
-  "allocated_bytes" => 0
-  "inner_timers" => Dict{String, Any}("nest 1"=>Dict{String, Any}("total_time_ns"=>611383374, "total_allocated_bytes"=>11888, "time_ns"=>726721166, "n_calls"=>1, "allocated_bytes"=>474662, "inner_timers"=>Dict{String, Any}("level 2.1"=>Dict{String, Any}("total_time_ns"=>0, "total_allocated_bytes"=>0, "time_ns"=>115773750, "n_calls"=>1, "allocated_bytes"=>8064, "inner_timers"=>Dict{String, Any}()), "level 2.2"=>Dict{String, Any}("total_time_ns"=>0, "total_allocated_bytes"=>0, "time_ns"=>495609624, "n_calls"=>20, "allocated_bytes"=>3824, "inner_timers"=>Dict{String, Any}()))))
-
-julia> using JSON3 # or JSON
-
-julia> JSON3.write(TimerOutputs.todict(to))
-"{\"total_time_ns\":712143250,\"total_allocated_bytes\":5680,\"time_ns\":0,\"n_calls\":0,\"allocated_bytes\":0,\"inner_timers\":{\"nest 1\":{\"total_time_ns\":605922416,\"total_allocated_bytes\":4000,\"time_ns\":712143250,\"n_calls\":1,\"allocated_bytes\":5680,\"inner_timers\":{\"level 2.1\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":106111333,\"n_calls\":1,\"allocated_bytes\":176,\"inner_timers\":{}},\"level 2.2\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":499811083,\"n_calls\":20,\"allocated_bytes\":3824,\"inner_timers\":{}}}}}}"
-```
-
 ## Flattening
 
 If sections are nested like in the example below:
@@ -502,6 +474,34 @@ shared with other users getting a timer with the same name. Also, this function
 is not recommended to be used extensively by libraries as the namespace is
 shared and collisions are possible if two libraries happen to use the same timer
 name.
+
+## Serialization
+
+Timers may be converted to a nested set of dictionaries with the (unexported) `TimerOutputs.todict` function. This can be used to serialize a timer as JSON, for example.
+
+```julia
+julia> to = TimerOutput();
+
+julia> @timeit to "nest 1" begin
+           sleep(0.1)
+           @timeit to "level 2.1" sleep(0.1)
+           for i in 1:20; @timeit to "level 2.2" sleep(0.02); end
+       end
+
+julia> TimerOutputs.todict(to)
+Dict{String, Any} with 6 entries:
+  "total_time_ns" => 726721166
+  "total_allocated_bytes" => 474662
+  "time_ns" => 0
+  "n_calls" => 0
+  "allocated_bytes" => 0
+  "inner_timers" => Dict{String, Any}("nest 1"=>Dict{String, Any}("total_time_ns"=>611383374, "total_allocated_bytes"=>11888, "time_ns"=>726721166, "n_calls"=>1, "allocated_bytes"=>474662, "inner_timers"=>Dict{String, Any}("level 2.1"=>Dict{String, Any}("total_time_ns"=>0, "total_allocated_bytes"=>0, "time_ns"=>115773750, "n_calls"=>1, "allocated_bytes"=>8064, "inner_timers"=>Dict{String, Any}()), "level 2.2"=>Dict{String, Any}("total_time_ns"=>0, "total_allocated_bytes"=>0, "time_ns"=>495609624, "n_calls"=>20, "allocated_bytes"=>3824, "inner_timers"=>Dict{String, Any}()))))
+
+julia> using JSON3 # or JSON
+
+julia> JSON3.write(TimerOutputs.todict(to))
+"{\"total_time_ns\":712143250,\"total_allocated_bytes\":5680,\"time_ns\":0,\"n_calls\":0,\"allocated_bytes\":0,\"inner_timers\":{\"nest 1\":{\"total_time_ns\":605922416,\"total_allocated_bytes\":4000,\"time_ns\":712143250,\"n_calls\":1,\"allocated_bytes\":5680,\"inner_timers\":{\"level 2.1\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":106111333,\"n_calls\":1,\"allocated_bytes\":176,\"inner_timers\":{}},\"level 2.2\":{\"total_time_ns\":0,\"total_allocated_bytes\":0,\"time_ns\":499811083,\"n_calls\":20,\"allocated_bytes\":3824,\"inner_timers\":{}}}}}}"
+```
 
 
 ## Overhead


### PR DESCRIPTION
for https://github.com/KristofferC/TimerOutputs.jl/pull/139

I also took the liberty of bumping the version- could we get a release with this?