### PR TITLE
Fix percentage formatting to 1 d.p.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.14"
+version = "0.5.15"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/show.jl
+++ b/src/show.jl
@@ -68,8 +68,8 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
     midrule       = linechars == :unicode ? "─" : "-"
     topbottomrule = linechars == :unicode ? "─" : "-"
     sec_ncalls = string(rpad("Section", name_length, " "), " ncalls  ")
-    time_headers = "   time   %tot" * (compact ? "" : "     avg")
-    alloc_headers = allocations ? ("  alloc   %tot" * (compact ? "" : "      avg")) : ""
+    time_headers = "   time    %tot" * (compact ? "" : "     avg")
+    alloc_headers = allocations ? ("  alloc    %tot" * (compact ? "" : "      avg")) : ""
     total_table_width = sum(textwidth.((sec_ncalls, time_headers, alloc_headers))) + 3
 
     # Just hardcoded shit to make things look nice
@@ -86,17 +86,17 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
         title = center(truncdots(title, textwidth(sec_ncalls)), textwidth(sec_ncalls))
 
         if compact
-            time_header       = "     Time     "
+            time_header       = "      Time     "
         else
-            time_header       = "        Time          "
+            time_header       = "         Time          "
         end
 
         time_underline = midrule^textwidth(time_header)
 
         if compact
-            allocation_header       = " Allocations  "
+            allocation_header       = "  Allocations  "
         else
-            allocation_header = "      Allocations      "
+            allocation_header = "       Allocations      "
         end
 
         alloc_underline = midrule^textwidth(allocation_header)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -53,14 +53,10 @@ function prettypercent(nominator, denominator)
         str = " - %"
     elseif denominator == 0
         str = "inf %"
-    elseif round(value) >= 100
-        str = string(@sprintf("%.0f", value), "%")
-    elseif round(value * 10) >= 100
-        str = string(@sprintf("%.1f", value), "%")
     else
-        str = string(@sprintf("%.2f", value), "%")
+        str = string(@sprintf("%.1f", value), "%")
     end
-    return str
+    return lpad(str, 6, " ")
 end
 
 function prettycount(t::Integer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,7 +271,7 @@ for (b, str) in ((9.999*1024,   "10.0KiB"), (99.999*1024,   " 100KiB"),
                  (9.999*1024^3, "10.0GiB"), (99.999*1024^3, " 100GiB"))
     @test prettymemory(b)   == str
 end
-for (num, den, str) in ((0.9999, 1, "100%"), (0.09999, 1, "10.0%"))
+for (num, den, str) in ((0.9999, 1, "100.0%"), (0.09999, 1, " 10.0%"))
     @test prettypercent(num, den) == str
 end
 for (t, str) in ((9.999*1024,   "10.0KiB"), (99.999*1024,   " 100KiB"),


### PR DESCRIPTION
Closes #141 

```
 ───────────────────────────────────────────────────
                         Time          Allocations  
                   ───────────────   ───────────────
  Total measured:      35.9ms            12.1MiB    

 Section   ncalls     time    %tot     alloc    %tot
 ───────────────────────────────────────────────────
 foobar         2   2.07μs   81.5%   2.94KiB  100.0%
   baz          2    150ns    5.9%     0.00B    0.0%
   foo          1    150ns    5.9%     0.00B    0.0%
   bar          1   60.0ns    2.4%     0.00B    0.0%
 foo            1    191ns    7.5%     0.00B    0.0%
 baz            2    150ns    5.9%     0.00B    0.0%
 bar            2    130ns    5.1%     0.00B    0.0%
 ───────────────────────────────────────────────────
 ────────────────────────────────────────────────────────────────────
                            Time                    Allocations      
                   ───────────────────────   ────────────────────────
 Tot / % measured:     36.2ms /   0.0%           12.1MiB /   0.0%    

 Section   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────
 foobar         2   2.07μs   81.5%  1.04μs   2.94KiB  100.0%  1.47KiB
   baz          2    150ns    5.9%  75.0ns     0.00B    0.0%    0.00B
   foo          1    150ns    5.9%   150ns     0.00B    0.0%    0.00B
   bar          1   60.0ns    2.4%  60.0ns     0.00B    0.0%    0.00B
 foo            1    191ns    7.5%   191ns     0.00B    0.0%    0.00B
 baz            2    150ns    5.9%  75.0ns     0.00B    0.0%    0.00B
 bar            2    130ns    5.1%  65.0ns     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────
 ─────────────────────────────────
 Section   ncalls     time    %tot
 ─────────────────────────────────
 foobar         2   2.07μs   81.5%
   baz          2    150ns    5.9%
   foo          1    150ns    5.9%
   bar          1   60.0ns    2.4%
 foo            1    191ns    7.5%
 baz            2    150ns    5.9%
 bar            2    130ns    5.1%
 ─────────────────────────────────
 ─────────────────────────────────────────
                            Time          
                   ───────────────────────
 Tot / % measured:     36.8ms /   0.0%    

 Section   ncalls     time    %tot     avg
 ─────────────────────────────────────────
 foobar         2   2.07μs   81.5%  1.04μs
   baz          2    150ns    5.9%  75.0ns
   foo          1    150ns    5.9%   150ns
   bar          1   60.0ns    2.4%  60.0ns
 foo            1    191ns    7.5%   191ns
 baz            2    150ns    5.9%  75.0ns
 bar            2    130ns    5.1%  65.0ns
 ─────────────────────────────────────────
```

If there are any %'s greater than 100% (which can happen in threaded merges) they will cause misalignment, but I think that's a reasonable bug to leave? 
(Perhaps to be fixed formally by a merge method that has a kwarg for parallelism factor that does auto division when merging, etc. but that's another issue)