### PR TITLE
Fix ordering of nested elements when `sortby = :firstexec`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.15"
+version = "0.5.16"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/show.jl
+++ b/src/show.jl
@@ -35,7 +35,9 @@ function Base.show(io::IO, to::TimerOutput; allocations::Bool = true, sortby::Sy
     name_length = max(9, max_name - max(0, requested_width - available_width))
 
     print_header(io, Δt, Δb, ∑t, ∑b, name_length, true, allocations, linechars, compact, title)
-    for timer in sort!(collect(values(to.inner_timers)); rev = !in(sortby, [:name, :firstexec]), by = x -> sortf(x, sortby))
+    rev = !in(sortby, [:name, :firstexec])
+    by(x) = sortf(x, sortby)
+    for timer in sort!(collect(values(to.inner_timers)); rev = rev, by = by)
         _print_timer(io, timer, ∑t, ∑b, 0, name_length, allocations, sortby, compact)
     end
     print_header(io, Δt, Δb, ∑t, ∑b, name_length, false, allocations, linechars, compact, title)
@@ -156,7 +158,9 @@ function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, ∑b::Integer, ind
     end
     print(io, "\n")
 
-    for timer in sort!(collect(values(to.inner_timers)), rev = sortby != :name, by = x -> sortf(x, sortby))
+    rev = !in(sortby, [:name, :firstexec])
+    by(x) = sortf(x, sortby)
+    for timer in sort!(collect(values(to.inner_timers)); rev = rev, by = by)
         _print_timer(io, timer, ∑t, ∑b, indent + 2, name_length, allocations, sortby, compact)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -559,20 +559,20 @@ end
     @timeit to "cccc" sleep(0.1)
 
     table = sprint((io, to)->show(io, to, sortby = :firstexec), to)
-
     @test match(r"cccc", table).offset < match(r"bbbb", table).offset < match(r"aaaa", table).offset
 
     to = TimerOutput()
     @timeit to "group" begin
-        @timeit to "cccc" sleep(0.1)
+        @timeit to "aaaa" sleep(0.1)
         @timeit to "bbbb" sleep(0.1)
         @timeit to "nested_group" begin sleep(0.1)
-            @timeit to "aaaa" sleep(0.1)
             @timeit to "cccc" sleep(0.1)
+            @timeit to "dddd" sleep(0.1)
         end
     end
 
-    @test match(r"cccc", table).offset < match(r"bbbb", table).offset < match(r"aaaa", table).offset
+    table = sprint((io, to)->show(io, to, sortby = :firstexec), to)
+    @test match(r"aaaa", table).offset < match(r"bbbb", table).offset < match(r"cccc", table).offset
 end
 
 @static if isdefined(Threads, Symbol("@spawn"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,6 +561,18 @@ end
     table = sprint((io, to)->show(io, to, sortby = :firstexec), to)
 
     @test match(r"cccc", table).offset < match(r"bbbb", table).offset < match(r"aaaa", table).offset
+
+    to = TimerOutput()
+    @timeit to "group" begin
+        @timeit to "cccc" sleep(0.1)
+        @timeit to "bbbb" sleep(0.1)
+        @timeit to "nested_group" begin sleep(0.1)
+            @timeit to "aaaa" sleep(0.1)
+            @timeit to "cccc" sleep(0.1)
+        end
+    end
+
+    @test match(r"cccc", table).offset < match(r"bbbb", table).offset < match(r"aaaa", table).offset
 end
 
 @static if isdefined(Threads, Symbol("@spawn"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -564,10 +564,9 @@ end
     to = TimerOutput()
     @timeit to "group" begin
         @timeit to "aaaa" sleep(0.1)
-        @timeit to "bbbb" sleep(0.1)
         @timeit to "nested_group" begin sleep(0.1)
+            @timeit to "bbbb" sleep(0.1)
             @timeit to "cccc" sleep(0.1)
-            @timeit to "dddd" sleep(0.1)
         end
     end
 


### PR DESCRIPTION
The ordering of nested elements was reversed when `sortby = :firstexec`:

```julia
julia> using TimerOutputs

julia> to = TimerOutput();

julia> @timeit to "group" begin
           @timeit to "sub1" sleep(0.1)
           @timeit to "sub2" sleep(0.1)
       end

julia> show(to; compact=true, sortby=:firstexec)
 ───────────────────────────────────────────────────
                         Time          Allocations
                   ───────────────   ───────────────
  Total measured:       46.0s            2.29MiB

 Section   ncalls     time    %tot     alloc    %tot
 ───────────────────────────────────────────────────
 group          1    202ms  100.0%   2.55KiB  100.0%
   sub2         1    101ms   50.0%      320B   12.3%
   sub1         1    101ms   50.0%      320B   12.3%
 ───────────────────────────────────────────────────
```