### PR TITLE
Reduce the chance of measuring TimerOutputs compilation time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+**/Manifest.toml
+tmp.jl

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -25,8 +25,9 @@ include("show.jl")
 include("utilities.jl")
 
 if Base.VERSION >= v"1.4.2"
-    include("precompile.jl")
+    include("compile.jl")
     _precompile_()
 end
+
 
 end # module

--- a/src/compile.jl
+++ b/src/compile.jl
@@ -1,3 +1,8 @@
+# To make it less likely that users measure TimerOutputs compilation time.
+let
+    to = TimerOutput()
+    @timeit to "1" string(1)
+end
 
 function _precompile_()
   ccall(:jl_generating_output, Cint, ()) == 1 || return nothing


### PR DESCRIPTION
On Julia 1.7.2 with TimerOutputs 0.5.17:

```julia
using TimerOutputs

n = 5
sleeptime = 0.1

# Warmup sleep. Just to be sure.
sleep(sleeptime)

@timeit to "total-time" begin
    for i in 1:n
        @timeit to "$i" sleep(sleeptime)
    end
end

show(to; compact=true, sortby=:firstexec)
```
```
 ──────────────────────────────────────────────────────
                            Time          Allocations
                      ───────────────   ───────────────
    Total measured:        1.83s            83.1MiB

 Section      ncalls     time    %tot     alloc    %tot
 ──────────────────────────────────────────────────────
 total-time        1    544ms  100.0%    661KiB  100.0%
   1               1    117ms   21.5%   7.88KiB    1.2%
   2               1    101ms   18.6%      176B    0.0%
   3               1    102ms   18.7%      176B    0.0%
   4               1    101ms   18.7%      176B    0.0%
   5               1    101ms   18.6%      480B    0.1%
 ──────────────────────────────────────────────────────
```
Note that 

1. the first call takes longer even though `sleep` doesn't have to be compiled, so something in `TimeOutputs` is being compiled.
2. ~~The time reported by the section doesn't add up: 117 + 101 + 102 + 101 + 101 = 522ms and not 544ms~~ EDIT: Nevermind. I was confused. This is probably the time it takes for the loop logic.
3. The total time reported is not the same as the total time for the section: 544ms is not the same as 1.83s.

## This PR

This PR fixes the first issue. I have no idea how to fix the "Total measured" time yet, or maybe that time does make sense?

```
 ──────────────────────────────────────────────────────
                            Time          Allocations
                      ───────────────   ───────────────
    Total measured:        1.18s            47.2MiB

 Section      ncalls     time    %tot     alloc    %tot
 ──────────────────────────────────────────────────────
 total-time        1    519ms  100.0%   13.6KiB  100.0%
   1               1    101ms   19.6%      144B    1.0%
   2               1    102ms   19.6%      144B    1.0%
   3               1    102ms   19.6%      144B    1.0%
   4               1    101ms   19.5%      144B    1.0%
   5               1    102ms   19.6%      144B    1.0%
 ──────────────────────────────────────────────────────
```