### PR TITLE
Add a typeassert to satisfy JET.

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -92,6 +92,7 @@ function Base.push!(to::TimerOutput, label::String)
             timer = maybe_timer
         end
     end
+    timer = timer::TimerOutput
     current_timer.prev_timer_label = label
     current_timer.prev_timer = timer
 


### PR DESCRIPTION
The `timer` could be nothing, so assert it won't.

```
  ═════ 2 possible errors found ═════
  ┌ @ /home/tim/Julia/pkg/CUDA/src/array.jl:138 CuArray{Int64}(CUDA.undef, CUDA.convert(Tuple{Vararg{Int64}}, dims))
  │┌ @ /home/tim/Julia/pkg/CUDA/src/array.jl:136 CuArray{Int64, 1}(CUDA.undef, dims)
  ││┌ @ /home/tim/Julia/pkg/CUDA/src/array.jl:125 CuArray{Int64, 1, CUDA.Mem.DeviceBuffer}(CUDA.undef, dims)
  │││┌ @ /home/tim/Julia/pkg/CUDA/src/array.jl:42 buf = CUDA.alloc(B, bufsize)
  ││││┌ @ /home/tim/Julia/depot/packages/TimerOutputs/jgSVI/src/TimerOutput.jl:229 CUDA.:(var"#alloc#165")(CUDA.nothing, #self#, _2, sz)
  │││││┌ @ /home/tim/Julia/depot/packages/TimerOutputs/jgSVI/src/TimerOutput.jl:232 accumulated_data#386 = push!(local_to#384, "alloc")
  ││││││┌ @ /home/tim/Julia/depot/packages/TimerOutputs/jgSVI/src/TimerOutput.jl:98 TimerOutputs.push!(to.timer_stack, timer)
  │││││││┌ @ array.jl:994 itemT = convert(T, item)
  ││││││││ no matching method found `convert(::Type{TimerOutput}, ::Nothing)`: itemT = convert(T::Type{TimerOutput}, item::Nothing)::Union{}
  │││││││└────────────────
  ││││││┌ @ /home/tim/Julia/depot/packages/TimerOutputs/jgSVI/src/TimerOutput.jl:99 timer.accumulated_data
  │││││││┌ @ Base.jl:42 Base.getfield(x, f)
  ││││││││ type Nothing has no field accumulated_data
  │││││││└──────────────
```

Noticed in https://github.com/JuliaGPU/CUDA.jl/pull/1577