### PR TITLE
Remove overhead of default InstrumentedFunction

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -142,7 +142,15 @@ struct InstrumentedFunction{F} <: Function
     name::String
 end
 
-InstrumentedFunction(f, t) = InstrumentedFunction(f, t, string(repr(f)))
+function funcname(f::F) where {F}
+    if @generated
+        string(repr(F.instance))
+    else
+        string(repr(f))
+    end
+end
+
+InstrumentedFunction(f, t) = InstrumentedFunction(f, t, funcname(f))
 
 function (inst::InstrumentedFunction)(args...; kwargs...)
     @timeit inst.t inst.name inst.func(args...; kwargs...)
@@ -155,4 +163,4 @@ Instruments `f` by the [`TimerOutput`](@ref) `t` returning an `InstrumentedFunct
 This function can be used just like `f`, but whenever it is called it stores timing
 results in `t`.
 """
-(t::TimerOutput)(f, name=string(repr(f))) = InstrumentedFunction(f, t, name)
+(t::TimerOutput)(f, name=funcname(f)) = InstrumentedFunction(f, t, name)


### PR DESCRIPTION
I recently found out about the very nice "instrumented function" feature introduced by @ericphanson in #152.

After trying it out, I noticed that by default it has some additional overhead and allocations associated to the creation of the string representation of the instrumented function using `repr`. The overhead disappears when one directly passes a string instead of using the default.

Here is a small example:

```julia
using TimerOutputs
using BenchmarkTools

identity_timed(x, to) = to(identity)(x)
identity_timed_alt(x, to) = to(identity, "identity")(x)

to = TimerOutput()
x = 3
@btime identity_timed($x, $to)       #  668.241 ns (4 allocations: 192 bytes)
@btime identity_timed_alt($x, $to)   #  47.087 ns (0 allocations: 0 bytes)
```

This PR completely removes the overhead in the first case, by using a generated function when possible to generate the function name.