### PR TITLE
remove line numbers from the macro created code

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -246,15 +246,15 @@ function _timer_expr(m::Module, is_debug::Bool, to::Union{Symbol, Expr, TimerOut
     end
 
     if is_debug
-        return quote
+        return Base.remove_linenums!(quote
             if $m.timeit_debug_enabled()
                 $timeit_block
             else
                 $ex
             end
-        end
+        end)
     else
-        return timeit_block
+        return Base.remove_linenums!(timeit_block)
     end
 end
 


### PR DESCRIPTION
```
julia> function foo(::Float64) end
foo (generic function with 1 method)

julia> @timeit "foo" foo(1)
ERROR: MethodError: no method matching foo(::Int64)

Closest candidates are:
  foo(::Float64)
   @ Main REPL[6]:1

Stacktrace:
 [1] top-level scope
   @ REPL[7]:1
```

Fixes https://github.com/KristofferC/TimerOutputs.jl/issues/77