### PR TITLE
remove the one leading space for all lines in show(); fixes line wrapping problem

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -114,25 +114,25 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
 
         header_str = string("  time  %tot  %timed")
         tot_midstr = string(sec_ncalls, "  ", header_str)
-        printstyled(io, " ", topbottomrule^total_table_width, "\n"; bold=true)
+        printstyled(io, topbottomrule^total_table_width, "\n"; bold=true)
         if ! (allocations == false && compact == true)
-            printstyled(io, " ", title; bold=true)
+            printstyled(io, title; bold=true)
             print(io, time_header)
             allocations && print(io, "   ", allocation_header)
             print(io, "\n")
-            print(io, " ", time_alloc_pading, time_underline)
+            print(io, time_alloc_pading, time_underline)
             allocations && print(io, "   ", alloc_underline)
             print(io, "\n")
-            print(io, " ", tot_meas_str, str_time)
+            print(io, tot_meas_str, str_time)
             allocations && print(io, "   ", str_alloc)
             print(io, "\n\n")
         end
-        print(io, " ", sec_ncalls, time_headers)
+        print(io, sec_ncalls, time_headers)
         allocations && print(io, "   ", alloc_headers)
         print(io, "\n")
-        print(io, " ", midrule^total_table_width, "\n")
+        print(io, midrule^total_table_width, "\n")
     else
-        printstyled(io, " ", topbottomrule^total_table_width; bold=true)
+        printstyled(io, topbottomrule^total_table_width; bold=true)
     end
 end
 
@@ -142,7 +142,6 @@ function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, ∑b::Integer, ind
     b = accum_data.allocs
 
     name = truncdots(to.name, name_length - indent)
-    print(io, " ")
     nc = accum_data.ncalls
     print(io, " "^indent, rpad(name, name_length + 2 - indent))
     print(io, lpad(prettycount(nc), 5, " "))


### PR DESCRIPTION
Dear Kristoffer,

This PR is a simple fix to #166. It removes all the leading spaces (" ") that you had in each line of output in print_timer in show.jl. This makes my output table fill the exact width available, without spilling over by 1 char as in your current master.

Note that the 1-char spillover can be predicted, eg for the 1st line of header here:
https://github.com/KristofferC/TimerOutputs.jl/blob/89f585e8f093e5a326c6f811b01359f6b1f19151/src/show.jl#L117
since it prints one space then `total_table_width` additional chars, giving a width of `total_table_width+1`.
You have otherwise done a perfect job of insuring that `total_table_width <= available_width`, I think.

Maybe no-one else has this problem, in which case, please ignore the PR.
But I'd be surprised if that were the case, since I'm in a very standard set-up: GNOME terminal, 80-char width.

Thanks again! Alex


