### PR TITLE
Avoid merge piracy with no arguments

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -125,7 +125,7 @@ end
 # merging timer outputs
 const merge_lock = ReentrantLock() # needed for merges of objects on different threads
 
-Base.merge(others::TimerOutput...) = merge!(TimerOutput(), others...)
+Base.merge(self::TimerOutput, others::TimerOutput...) = merge!(TimerOutput(), self, others...)
 function Base.merge!(self::TimerOutput, others::TimerOutput...; tree_point = String[])
     lock(merge_lock) do
         for other in others

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -512,7 +512,10 @@ TimerOutputs.enable_debug_timings(@__MODULE__)
 
     @timeit to3 "bar" identity(nothing)
 
+    @test_throws MethodError merge()
+
     to_merged = merge(to1, to2, to3)
+    @test to_merged !== to1
     merge!(to1, to2, to3)
 
     for to in [to1, to_merged]


### PR DESCRIPTION
Since merge is defined also for empty argument list,
```Base.merge(others::TimerOutput...) = merge!(TimerOutput(), others...)```
`Base.merge()` now returns TimerOutput().

Apart from being weird, it may screw JET report_package on third party projects.
```
function validate(validations::Dict...)::Dict
    return merge(validations...)
end
═════ 1 possible error found ═════
┌ validate(cfg::SCEngine.WindowCfg) @ SCEngine /home/dani/source/repos/sc-engine/src/core/core.cfg.jl:384
│┌ validate(::Vector{SCEngine.WindowSizeCfg}) @ SCEngine /home/dani/source/repos/sc-engine/src/core/validate.cfg.jl:7
││ no matching method found `convert(::Type{AbstractDict{String, String}}, ::TimerOutputs.TimerOutput)`: convert(ValidationResult, _4::TimerOutputs.TimerOutput)
│└────────────────────
```