### PR TITLE
Don't use displaysize in `show` unless limit=true is set

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -14,7 +14,7 @@ function Base.show(io::IO, to::TimerOutput; allocations::Bool = true, sortby::Sy
     ∑t, ∑b = to.flattened ? to.totmeasured : totmeasured(to)
 
     max_name = longest_name(to)
-    available_width = displaysize(io)[2]
+    available_width = get(io, :limit, false) ? displaysize(io)[2] : typemax(Int)
     requested_width = max_name
     if compact
         if allocations


### PR DESCRIPTION
Essentially the same issue as https://github.com/JuliaSparse/SparseArrays.jl/issues/233.

Current behaviour (ignores `:limit => false`):

```julia
julia> using TimerOutputs

julia> @timeit String('a':'z')^4 1+1;

julia> show(stdout, get_defaultimer())
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                            Time                    Allocations      
                                                                                                                   ───────────────────────   ────────────────────────
                                                 Tot / % measured:                                                     5.95ms /   0.1%            136KiB /   0.2%    

Section                                                                                                    ncalls     time    %tot     avg     alloc    %tot      avg
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz        1   7.39μs  100.0%  7.39μs      272B  100.0%     272B
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
julia> sprint(show, get_defaultimer(); context = :limit => false) |> println
────────────────────────────────────────────────────────────────────────────────
                                       Time                    Allocations      
                              ───────────────────────   ────────────────────────
      Tot / % measured:           7.63ms /   0.1%            190KiB /   0.1%    

Section               ncalls     time    %tot     avg     alloc    %tot      avg
────────────────────────────────────────────────────────────────────────────────
abcdefghijklmnopqr...      1   7.39μs  100.0%  7.39μs      272B  100.0%     272B
────────────────────────────────────────────────────────────────────────────────
```

With this PR:

```julia
julia> sprint(show, get_defaultimer(); context = :limit => false) |> println
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                            Time                    Allocations      
                                                                                                                   ───────────────────────   ────────────────────────
                                                 Tot / % measured:                                                      8.96s /   0.0%           20.8MiB /   0.0%    

Section                                                                                                    ncalls     time    %tot     avg     alloc    %tot      avg
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz        1   7.39μs  100.0%  7.39μs      272B  100.0%     272B
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```