### PR TITLE
Fix using timeit with an empty label

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.27"
+version = "0.5.26"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.26"
+version = "0.5.27"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -30,7 +30,7 @@ mutable struct TimerOutput
     flattened::Bool
     enabled::Bool
     totmeasured::Tuple{Int64,Int64}
-    prev_timer_label::String
+    prev_timer_label::Union{String,Nothing}
     prev_timer::Union{TimerOutput,Nothing}
 
     function TimerOutput(label::String = "root")
@@ -38,7 +38,7 @@ mutable struct TimerOutput
         accumulated_data = TimeData()
         inner_timers = Dict{String,TimerOutput}()
         timer_stack = TimerOutput[]
-        return new(start_data, accumulated_data, inner_timers, timer_stack, label, false, true, (0, 0), "", nothing)
+        return new(start_data, accumulated_data, inner_timers, timer_stack, label, false, true, (0, 0), nothing, nothing)
     end
 
     # Jeez...

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -699,3 +699,9 @@ end
     t(1)
     ncalls(to.inner_timers[repr(s)]) == 1
 end
+
+@testset "@timeit works with an empty label" begin
+    to = TimerOutput()
+    @timeit to "" begin end
+    @test ncalls(to.inner_timers[""]) == 1
+end


### PR DESCRIPTION
This PR fixes an exception thrown when using `@timeit` with an empty label.
Normally you don't do this, but I have a test where this happens.
