### PR TITLE
Add deserialisation capabilities for raw JSON

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -8,9 +8,8 @@ function Base.show(io::IO, to::TimerOutput; allocations::Bool = true, sortby::Sy
     sortby  in (:time, :ncalls, :allocations, :name, :firstexec) || throw(ArgumentError("sortby should be :time, :allocations, :ncalls, :name, or :firstexec, got $sortby"))
     linechars in (:unicode, :ascii)                  || throw(ArgumentError("linechars should be :unicode or :ascii, got $linechars"))
 
-    t₀, b₀ = to.start_data.time, to.start_data.allocs
-    t₁, b₁ = time_ns(), gc_bytes()
-    Δt, Δb = t₁ - t₀, b₁ - b₀
+    # make sure the deltas we report actually match the time elapsed - can cause problems if we go back to look at results at a later time
+    Δt, Δb = totmeasured(to)
     ∑t, ∑b = to.flattened ? to.totmeasured : totmeasured(to)
 
     max_name = longest_name(to)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -120,12 +120,29 @@ Converts a `TimerOutput` into a nested set of dictionaries, with keys and value 
 """
 function todict(to::TimerOutput)
     return Dict{String,Any}(
+        "name" => to.name,
         "n_calls" => ncalls(to),
         "time_ns" => time(to),
         "allocated_bytes" => allocated(to),
         "total_allocated_bytes" => totallocated(to),
         "total_time_ns" => tottime(to),
-        "inner_timers" => Dict{String, Any}(k => todict(v) for (k,v) in to.inner_timers)
+        "inner_timers" => Dict{String, Any}(k => todict(v) for (k,v) in to.inner_timers),
+        "timer_stack" => todict.(to.timer_stack),
+        "start_time_ns" => firstexec(to),
+        "start_data" => todict(to.start_data),
+        "flattened" => to.flattened,
+        "enabled" => to.enabled,
+        "prev_timer_label" => to.prev_timer_label,
+        "prev_timer" => isnothing(to.prev_timer) ? nothing : todict(to.prev_timer)        
+    )
+end
+
+function todict(td::TimeData)
+    return Dict{String, Any}(
+        "n_calls" => ncalls(td),
+        "time_ns" => time(td),
+        "allocated_bytes" => allocated(td),
+        "start_time_ns" => firstexec(td)
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -682,6 +682,9 @@ end
     end
     
     compare(to, todict(to))
+
+    # make sure we can serialise and deserialise properly
+    @test TimerOutput(todict(to)) == to
 end
 
 @testset "InstrumentedFunctions" begin


### PR DESCRIPTION
Hi, I've had a go at adding some deserialisation capabilities for the current simple JSON functionality we have (with the `todict` function). Ideally something like [#136](https://github.com/KristofferC/TimerOutputs.jl/pull/136) (particularly the suggestion to use [StructTypes and JSON3](https://github.com/KristofferC/TimerOutputs.jl/pull/136#issuecomment-971546736))would be much nicer to have, but this might do in the interim?