### PR TITLE
Add public way to start and stop a labelled section

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,34 +17,23 @@ jobs:
         version:
           - 'lts'
           - '1'
-          - 'nightly'
+          - 'pre'
+          # - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-latest
           - windows-latest
-        arch:
-          - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Similar information is available for allocations:
 It is also possible to manually start and stop a timed section.
 
 ```julia
-section = start_timed_section!(to, "my section")
+section = begin_timed_section!(to, "my section")
 foo()
-stop_timed_section!(to, section)
+end_timed_section!(to, section)
 ```
 
 ## Settings for printing:

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Similar information is available for allocations:
 
 ```
  ────────────────────────────────────────────────────────────────────────
-                                Time                    Allocations      
+                                Time                    Allocations
                        ───────────────────────   ────────────────────────
-   Tot / % measured:        7.99s /  39.1%            207MiB /  46.7%    
+   Tot / % measured:        7.99s /  39.1%            207MiB /  46.7%
 
  Section       ncalls     time    %tot     avg     alloc    %tot      avg
  ────────────────────────────────────────────────────────────────────────
@@ -139,6 +139,14 @@ Similar information is available for allocations:
  funcdef            1   94.4μs    0.0%  94.4μs     0.00B    0.0%    0.00B
  foo                1   1.50μs    0.0%  1.50μs     0.00B    0.0%    0.00B
  ────────────────────────────────────────────────────────────────────────
+```
+
+It is also possible to manually start and stop a timed section.
+
+```julia
+section = start_timed_section!(to, "my section")
+foo()
+stop_timed_section!(to, section)
 ```
 
 ## Settings for printing:

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -300,19 +300,48 @@ end
 # Doesn't hurt to keep it for a while though
 timeit(f::Function, label::String) = timeit(f, DEFAULT_TIMER, label)
 function timeit(f::Function, to::TimerOutput, label::String)
-    accumulated_data = push!(to, label)
-    b₀ = gc_bytes()
-    t₀ = time_ns()
+    section = start_timed_section!(to, label)
     local val
     try
         val = f()
     finally
-        accumulated_data.time += time_ns() - t₀
-        accumulated_data.allocs += gc_bytes() - b₀
-        accumulated_data.ncalls += 1
-        pop!(to)
+        stop_timed_section!(to, section)
     end
     return val
+end
+
+struct SectionTimeData
+    label::String # not needed for stopping, but useful for debugging passing this object around
+    data::TimeData
+    allocs_start::Int64
+    time_start::Int64
+end
+
+"""
+    start_timed_section!([to::TimerOutput=DEFAULT_TIMER], label::String)
+
+Start a timed section with the given label. Returns a `SectionTimeData` object that should
+be passed to `stop_timed_section!` when the section is done.
+"""
+start_timed_section!(label::String) = start_timed_section!(DEFAULT_TIMER, label)
+function start_timed_section!(to::TimerOutput, label::String)
+    data = push!(to, label)
+    b₀ = gc_bytes()
+    t₀ = time_ns()
+    return SectionTimeData(label, data, b₀, t₀)
+end
+
+"""
+    stop_timed_section!([to::TimerOutput=DEFAULT_TIMER], section::SectionTimeData)
+
+Stop a timed section started with `start_timed_section!`.
+"""
+stop_timed_section!(section::SectionTimeData) = stop_timed_section!(DEFAULT_TIMER, section)
+function stop_timed_section!(to::TimerOutput, section::SectionTimeData)
+    section.data.time += time_ns() - section.time_start
+    section.data.allocs += gc_bytes() - section.allocs_start
+    section.data.ncalls += 1
+    return pop!(to)
 end
 
 Base.haskey(to::TimerOutput, name::String) = haskey(to.inner_timers, name)

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -300,12 +300,12 @@ end
 # Doesn't hurt to keep it for a while though
 timeit(f::Function, label::String) = timeit(f, DEFAULT_TIMER, label)
 function timeit(f::Function, to::TimerOutput, label::String)
-    section = start_timed_section!(to, label)
+    section = begin_timed_section!(to, label)
     local val
     try
         val = f()
     finally
-        stop_timed_section!(to, section)
+        end_timed_section!(to, section)
     end
     return val
 end
@@ -318,13 +318,13 @@ struct SectionTimeData
 end
 
 """
-    start_timed_section!([to::TimerOutput=DEFAULT_TIMER], label::String)
+    begin_timed_section!([to::TimerOutput=DEFAULT_TIMER], label::String)
 
-Start a timed section with the given label. Returns a `SectionTimeData` object that should
-be passed to `stop_timed_section!` when the section is done.
+Start timing a section with the given label. Returns a `SectionTimeData` object that should
+be passed to `end_timed_section!` when the section is done.
 """
-start_timed_section!(label::String) = start_timed_section!(DEFAULT_TIMER, label)
-function start_timed_section!(to::TimerOutput, label::String)
+begin_timed_section!(label::String) = begin_timed_section!(DEFAULT_TIMER, label)
+function begin_timed_section!(to::TimerOutput, label::String)
     data = push!(to, label)
     b₀ = gc_bytes()
     t₀ = time_ns()
@@ -332,12 +332,13 @@ function start_timed_section!(to::TimerOutput, label::String)
 end
 
 """
-    stop_timed_section!([to::TimerOutput=DEFAULT_TIMER], section::SectionTimeData)
+    end_timed_section!([to::TimerOutput=DEFAULT_TIMER], section::SectionTimeData)
 
-Stop a timed section started with `start_timed_section!`.
+Stop timing a section started with `begin_timed_section!`. Should be passed a `SectionTimeData` object
+that was returned by `begin_timed_section!`.
 """
-stop_timed_section!(section::SectionTimeData) = stop_timed_section!(DEFAULT_TIMER, section)
-function stop_timed_section!(to::TimerOutput, section::SectionTimeData)
+end_timed_section!(section::SectionTimeData) = end_timed_section!(DEFAULT_TIMER, section)
+function end_timed_section!(to::TimerOutput, section::SectionTimeData)
     section.data.time += time_ns() - section.time_start
     section.data.allocs += gc_bytes() - section.allocs_start
     section.data.ncalls += 1

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -5,7 +5,7 @@ using ExprTools
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,
                     enable_timer!, disable_timer!, @notimeit, get_timer,
-                    start_timed_section!, stop_timed_section!
+                    begin_timed_section!, end_timed_section!
 
 
 function gc_bytes()

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -4,7 +4,8 @@ using ExprTools
 
 import Base: show, time_ns
 export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,
-                    enable_timer!, disable_timer!, @notimeit, get_timer
+                    enable_timer!, disable_timer!, @notimeit, get_timer,
+                    start_timed_section!, stop_timed_section!
 
 
 function gc_bytes()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,15 +40,21 @@ end
 @timeit to "sleep" sleep(0.1)
 @timeit to "sleep" sleep(0.1)
 @timeit to "sleep" sleep(0.1)
+section = start_timed_section!(to, "sleep")
+sleep(0.1)
+stop_timed_section!(to, section)
 
 @timeit "sleep" sleep(0.1)
 @timeit "sleep" sleep(0.1)
 @timeit "sleep" sleep(0.1)
+section = start_timed_section!("sleep")
+sleep(0.1)
+stop_timed_section!(section)
 
 @test haskey(to, "sleep")
 @test !haskey(to, "slep")
-@test ncalls(to["sleep"]) == 4
-@test ncalls(DEFAULT_TIMER["sleep"]) == 4
+@test ncalls(to["sleep"]) == 5
+@test ncalls(DEFAULT_TIMER["sleep"]) == 5
 
 
 # Check reset works
@@ -680,7 +686,7 @@ end
             compare(timer, obj)
         end
     end
-    
+
     compare(to, todict(to))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,9 +43,9 @@ end
 timeit(to, "sleep") do
     sleep(0.1)
 end
-section = start_timed_section!(to, "sleep")
+section = begin_timed_section!(to, "sleep")
 sleep(0.1)
-stop_timed_section!(to, section)
+end_timed_section!(to, section)
 
 @timeit "sleep" sleep(0.1)
 @timeit "sleep" sleep(0.1)
@@ -53,9 +53,9 @@ stop_timed_section!(to, section)
 timeit("sleep") do
     sleep(0.1)
 end
-section = start_timed_section!("sleep")
+section = begin_timed_section!("sleep")
 sleep(0.1)
-stop_timed_section!(section)
+end_timed_section!(section)
 
 @test haskey(to, "sleep")
 @test !haskey(to, "slep")
@@ -715,11 +715,11 @@ end
 @testset "Interleaved sections" begin
     to = TimerOutput()
 
-    section1 = start_timed_section!(to, "1")
+    section1 = begin_timed_section!(to, "1")
         sleep(0.1)
-        section2 = start_timed_section!(to, "2")
+        section2 = begin_timed_section!(to, "2")
             sleep(0.1)
-    stop_timed_section!(to, section1)
+    end_timed_section!(to, section1)
             sleep(0.1)
-        stop_timed_section!(to, section2)
+        end_timed_section!(to, section2)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,9 @@ end
 @timeit to "sleep" sleep(0.1)
 @timeit to "sleep" sleep(0.1)
 @timeit to "sleep" sleep(0.1)
+timeit(to, "sleep") do
+    sleep(0.1)
+end
 section = start_timed_section!(to, "sleep")
 sleep(0.1)
 stop_timed_section!(to, section)
@@ -47,14 +50,17 @@ stop_timed_section!(to, section)
 @timeit "sleep" sleep(0.1)
 @timeit "sleep" sleep(0.1)
 @timeit "sleep" sleep(0.1)
+timeit("sleep") do
+    sleep(0.1)
+end
 section = start_timed_section!("sleep")
 sleep(0.1)
 stop_timed_section!(section)
 
 @test haskey(to, "sleep")
 @test !haskey(to, "slep")
-@test ncalls(to["sleep"]) == 5
-@test ncalls(DEFAULT_TIMER["sleep"]) == 5
+@test ncalls(to["sleep"]) == 6
+@test ncalls(DEFAULT_TIMER["sleep"]) == 6
 
 
 # Check reset works

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -705,3 +705,15 @@ end
     t(1)
     ncalls(to.inner_timers[repr(s)]) == 1
 end
+
+@testset "Interleaved sections" begin
+    to = TimerOutput()
+
+    section1 = start_timed_section!(to, "1")
+        sleep(0.1)
+        section2 = start_timed_section!(to, "2")
+            sleep(0.1)
+    stop_timed_section!(to, section1)
+            sleep(0.1)
+        stop_timed_section!(to, section2)
+end


### PR DESCRIPTION
Useful for if you cannot wrap the thing you're timing in `@timeit` or `timeit(f, ...`.