### PR TITLE
Add FlameGraphsExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,20 @@ version = "0.5.26"
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[weakdeps]
+FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
+
 [compat]
 ExprTools = "0.1.0"
+FlameGraphs = "1"
 julia = "1.10"
 
 [extras]
+FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[extensions]
+FlameGraphsExt = "FlameGraphs"
+
 [targets]
-test = ["Test"]
+test = ["Test", "FlameGraphs"]

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -1,0 +1,50 @@
+module FlameGraphsExt
+
+using TimerOutputs
+using FlameGraphs: FlameGraphs
+using FlameGraphs.LeftChildRightSiblingTrees: Node, addchild
+using Base.StackTraces: StackFrame
+
+
+function FlameGraphs.flamegraph(to::TimerOutput)
+    # Skip the very top-level node, which contains no useful data
+    node_data = _flamegraph_frame(to, to.start_data.time; toplevel=true)
+    root = Node(node_data)
+    return _to_flamegraph(to, root, to.start_data.time)
+end
+
+## internals
+
+function max_end_time(to::TimerOutput)
+    return maximum(child.start_data.time + child.accumulated_data.time for child in values(to.inner_timers))
+end
+
+# Make a flat frame for this TimerOutput
+function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false)
+    # TODO: Use a better conversion to a StackFrame so this contains the right kind of data
+    tt = Symbol(to.name)
+    sf = StackFrame(tt, Symbol("none"), 0, nothing, false, false, UInt64(0x0))
+    status = 0x0  # "default" status -- See FlameGraphs.jl
+    start = to.start_data.time - start_ns
+    # TODO: is this supposed to be inclusive or exclusive?
+    if toplevel
+        # The root frame covers the total time being measured, so start when the first node
+        # was created, and stop when the last node was finished.
+        range = Int(start) : Int(start + (max_end_time(to) - start_ns))
+    else
+        #range = Int(start) : Int(start + TimerOutputs.tottime(to))
+        range = Int(start) : Int(start + to.accumulated_data.time)
+    end
+    return FlameGraphs.NodeData(sf, status, range)
+end
+
+function _to_flamegraph(to::TimerOutput, root, start_ns)
+    for (k, child) in to.inner_timers
+        node_data = _flamegraph_frame(child, start_ns)
+        node = addchild(root, node_data)
+        _to_flamegraph(child, node, start_ns)
+    end
+    return root
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Test
 import TimerOutputs: DEFAULT_TIMER, ncalls, flatten,
                      prettytime, prettymemory, prettypercent, prettycount, todict
 
+using FlameGraphs
+
 reset_timer!()
 
 # Timing from modules that don't import much
@@ -722,9 +724,23 @@ end
             sleep(0.1)
         end_timed_section!(to, section2)
 end
-  
+
 @testset "@timeit works with an empty label" begin
     to = TimerOutput()
     @timeit to "" begin end
     @test ncalls(to.inner_timers[""]) == 1
+end
+
+@testset "FlameGraphsExt" begin
+    to = TimerOutput()
+    @timeit to "1" begin
+        sleep(0.1)
+        @timeit to "2" begin
+            sleep(0.1)
+            @timeit to "3" begin
+                sleep(0.1)
+            end
+        end
+    end
+    flamegraph(to)
 end


### PR DESCRIPTION
Building on https://github.com/KristofferC/TimerOutputs.jl/pull/92 now that we can do extensions.

Quoting @nhdaly
> Since TimerOutputs are already nested timings, they map 1:1 to a FlameGraph profile. This simply adds the option to export a FlameGraphs.jl FlameGraph profile object, which can then be displayed via many of the flame-graph compatible display packages: ProfileView, ProfileSVG, etc.

```
using TimerOutputs, ProfileView
to = TimerOutput()
@timeit to "1" begin
    sleep(0.1)
    @timeit to "2" begin
        sleep(0.1)
        @timeit to "3" begin
            sleep(0.1)
        end
    end
end
ProfileView.view(ProfileView.flamegraph(to))
```

Related: A proposal to special case FlameGraphs that only populate `func` with meaningful information https://github.com/timholy/ProfileView.jl/pull/242


![Screenshot 2025-02-19 at 10 14 29 AM](https://github.com/user-attachments/assets/25a936b9-cce6-437f-a5c5-79a25dfd864b)
