### PR TITLE
improve flamegraph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,12 @@ end
 ProfileView.view(flamegraph(to))
 ```
 
+You may want to crop the span of the graph to the children, not how long `to` has been open.
+To do that use `crop_root=true`
+```
+ProfileView.view(flamegraph(to, crop_root=true))
+```
+
 ## Overhead
 
 There is a small overhead in timing a section (0.25 μs) which means that this package is not suitable for measuring sections that finish very quickly.

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -54,13 +54,12 @@ function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_roo
         # was created, and stop when the last node was finished.
         _start = crop_root ? min_start_time(to) : to.start_data.time
         _end = max_end_time(to)
-        range = (Int(_start) : Int(_end)) .- start_ns
     else
         #range = Int(start) : Int(start + TimerOutputs.tottime(to))
         _start = to.start_data.time
         _end = to.start_data.time + to.accumulated_data.time
-        range = (Int(_start) : Int(_end)) .- start_ns
     end
+    range = (Int(_start) : Int(_end)) .- start_ns
     return FlameGraphs.NodeData(sf, status, range)
 end
 

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -1,39 +1,60 @@
 module FlameGraphsExt
 
 using TimerOutputs
-using FlameGraphs: FlameGraphs
+using TimerOutputs: prettytime
+using FlameGraphs: FlameGraphs, NodeData
 using FlameGraphs.LeftChildRightSiblingTrees: Node, addchild
 using Base.StackTraces: StackFrame
 
+"""
+    flamegraph(to::TimerOutput; crop_root = false)
 
-function FlameGraphs.flamegraph(to::TimerOutput)
+Create a flamegraph from a TimerOutput. The flamegraph will show the time spent in each
+function, with the width of each box proportional to the time spent in that function.
+Use `crop_root = true` to crop the root node to the first and last child nodes.
+"""
+function FlameGraphs.flamegraph(to::TimerOutput; crop_root = false)
     # Skip the very top-level node, which contains no useful data
-    node_data = _flamegraph_frame(to, to.start_data.time; toplevel=true)
+    very_start = crop_root ? min_start_time(to) : to.start_data.time
+    node_data = _flamegraph_frame(to, very_start; toplevel=true, crop_root)
     root = Node(node_data)
-    return _to_flamegraph(to, root, to.start_data.time)
+    return _to_flamegraph(to, root, very_start)
 end
 
 ## internals
 
+function min_start_time(to::TimerOutput)
+    return minimum(child.start_data.time for child in values(to.inner_timers))
+end
+
 function max_end_time(to::TimerOutput)
-    return maximum(child.start_data.time + child.accumulated_data.time for child in values(to.inner_timers))
+    self_end = to.start_data.time + to.accumulated_data.time
+    if isempty(to.inner_timers)
+        return self_end
+    end
+    # Compute max end time considering both direct end time and all inner timers
+    return max(self_end, maximum(max_end_time(child) for child in values(to.inner_timers)))
 end
 
 # Make a flat frame for this TimerOutput
-function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false)
+function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_root = true)
     # TODO: Use a better conversion to a StackFrame so this contains the right kind of data
-    tt = Symbol(to.name)
-    sf = StackFrame(tt, Symbol("none"), 0, nothing, false, false, UInt64(0x0))
+    tt = Symbol(string(to.name, " (", strip(prettytime(to.accumulated_data.time)), ")"))
+    # Set the pointer to ensure the sf is unique
+    sf = StackFrame(tt, Symbol("none"), 0, nothing, false, false, Base.objectid(to))
     status = 0x0  # "default" status -- See FlameGraphs.jl
-    start = to.start_data.time - start_ns
     # TODO: is this supposed to be inclusive or exclusive?
     if toplevel
         # The root frame covers the total time being measured, so start when the first node
         # was created, and stop when the last node was finished.
-        range = Int(start) : Int(start + (max_end_time(to) - start_ns))
+        _start = crop_root ? min_start_time(to) : to.start_data.time
+        _end = max_end_time(to)
+        range = (Int(_start) : Int(_end)) .- start_ns
     else
         #range = Int(start) : Int(start + TimerOutputs.tottime(to))
-        range = Int(start) : Int(start + to.accumulated_data.time)
+        _start = to.start_data.time
+        _end = to.start_data.time + to.accumulated_data.time
+        range = (Int(_start) : Int(_end)) .- start_ns
     end
     return FlameGraphs.NodeData(sf, status, range)
 end

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -39,7 +39,14 @@ end
 # Make a flat frame for this TimerOutput
 function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_root = true)
     # TODO: Use a better conversion to a StackFrame so this contains the right kind of data
-    tt = Symbol(string(to.name, " (", strip(prettytime(to.accumulated_data.time)), ")"))
+    nc = to.accumulated_data.ncalls
+    tt_str = string(to.name, " (", strip(prettytime(to.accumulated_data.time)))
+    if to.accumulated_data.ncalls > 1
+        avg = to.accumulated_data.time / to.accumulated_data.ncalls
+        tt_str *= string(": ", nc, " calls ", strip(prettytime(avg)), " avg")
+    end
+    tt_str *= ")"
+    tt = Symbol(tt_str)
     # Set the pointer to ensure the sf is unique
     sf = StackFrame(tt, Symbol("none"), 0, nothing, false, false, Base.objectid(to))
     status = 0x0  # "default" status -- See FlameGraphs.jl

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -39,13 +39,11 @@ end
 # Make a flat frame for this TimerOutput
 function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_root = true)
     # TODO: Use a better conversion to a StackFrame so this contains the right kind of data
-    nc = to.accumulated_data.ncalls
-    tt_str = string(to.name, " (", strip(prettytime(to.accumulated_data.time)))
+    tt_str = string(to.name, " ", strip(prettytime(to.accumulated_data.time)))
     if to.accumulated_data.ncalls > 1
         avg = to.accumulated_data.time / to.accumulated_data.ncalls
-        tt_str *= string(": ", nc, " calls ", strip(prettytime(avg)), " avg")
+        tt_str *= string(" ", to.accumulated_data.ncalls, "×", strip(prettytime(avg)), " μ")
     end
-    tt_str *= ")"
     tt = Symbol(tt_str)
     # Set the pointer to ensure the sf is unique
     sf = StackFrame(tt, Symbol("none"), 0, nothing, false, false, Base.objectid(to))

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -42,7 +42,7 @@ function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_roo
     tt_str = string(to.name, " ", strip(prettytime(to.accumulated_data.time)))
     if to.accumulated_data.ncalls > 1
         avg = to.accumulated_data.time / to.accumulated_data.ncalls
-        tt_str *= string(" ", to.accumulated_data.ncalls, "×", strip(prettytime(avg)), " μ")
+        tt_str *= string(" ", to.accumulated_data.ncalls, "×μ", strip(prettytime(avg)))
     end
     tt = Symbol(tt_str)
     # Set the pointer to ensure the sf is unique

--- a/ext/FlameGraphsExt/FlameGraphsExt.jl
+++ b/ext/FlameGraphsExt/FlameGraphsExt.jl
@@ -37,7 +37,7 @@ function max_end_time(to::TimerOutput)
 end
 
 # Make a flat frame for this TimerOutput
-function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_root = true)
+function _flamegraph_frame(to::TimerOutput, start_ns; toplevel = false, crop_root = false)
     # TODO: Use a better conversion to a StackFrame so this contains the right kind of data
     tt_str = string(to.name, " ", strip(prettytime(to.accumulated_data.time)))
     if to.accumulated_data.ncalls > 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -733,14 +733,29 @@ end
 
 @testset "FlameGraphsExt" begin
     to = TimerOutput()
-    @timeit to "1" begin
-        sleep(0.1)
-        @timeit to "2" begin
+    begin
+        func() = @timeit to "func" sleep(0.1)
+        @timeit to "foo 1" begin
             sleep(0.1)
-            @timeit to "3" begin
+            @timeit to "bar" begin
                 sleep(0.1)
+                @timeit to "baz" begin
+                    sleep(0.1)
+                    func()
+                end
+            end
+        end
+        @timeit to "foo 2" begin
+            sleep(0.1)
+            @timeit to "bar" begin
+                sleep(0.1)
+                @timeit to "baz" begin
+                    sleep(0.1)
+                    func()
+                end
             end
         end
     end
     flamegraph(to)
+    flamegraph(to, crop_root=true)
 end


### PR DESCRIPTION
Using ProfileView v1.10.1

```
using ProfileView, TimerOutputs
to = TimerOutput()
begin
    func() = @timeit to "func" sleep(0.1)
    @timeit to "foo 1" begin
        sleep(0.1)
        @timeit to "bar" begin
            sleep(0.1)
            @timeit to "baz" begin
                sleep(0.1)
                func()
                func()
            end
        end
    end
    @timeit to "foo 2" begin
        sleep(0.1)
        @timeit to "bar" begin
            sleep(0.1)
            @timeit to "baz" begin
                sleep(0.1)
                func()
                func()
            end
        end
    end
end
ProfileView.view(flamegraph(to))
```
![Screenshot 2025-02-22 at 8 09 43 PM](https://github.com/user-attachments/assets/14802dca-d3d4-4245-9bdf-4d0adc37f172)



I also added a way to crop the root, in case the import span is any children (which it often is in my use cases)
```
ProfileView.view(flamegraph(to, crop_root=true))
```
![Screenshot 2025-02-22 at 8 10 02 PM](https://github.com/user-attachments/assets/aa4e103b-3456-4ada-932e-7dd4183d5546)

