### PR TITLE
Add %par(ent)

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -148,13 +148,15 @@ function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, tparent::Integer, 
 
     print(io, "   ", lpad(prettytime(t),        6, " "))
     print(io, "  ",  lpad(prettypercent(t, ∑t), 5, " "))
-    print(io, "  ",  lpad(prettypercent(t, tparent, decimal=false), 3, " "))
+    t_par_str = indent == 0 ? "    " : prettypercent(t, tparent, decimal=false)
+    print(io, "  ",  lpad(t_par_str, 3, " "))
     !compact && print(io, "  ",  rpad(prettytime(t / nc), 6, " "))
 
     if allocations
     print(io, "   ", rpad(prettymemory(b),      9, " "))
     print(io, rpad(prettypercent(b, ∑b), 5, " "))
-    print(io, "  ", lpad(prettypercent(b, bparent, decimal=false), 3, " "))
+    b_par_str = indent == 0 ? "    " : prettypercent(b, bparent, decimal=false)
+    print(io, "  ", b_par_str)
     !compact && print(io, "  ",    lpad(prettymemory(b / nc), 5, " "))
     end
     print(io, "\n")

--- a/src/show.jl
+++ b/src/show.jl
@@ -38,7 +38,7 @@ function Base.show(io::IO, to::TimerOutput; allocations::Bool = true, sortby::Sy
     rev = !in(sortby, [:name, :firstexec])
     by(x) = sortf(x, sortby)
     for timer in sort!(collect(values(to.inner_timers)); rev = rev, by = by)
-        _print_timer(io, timer, ∑t, ∑b, 0, name_length, allocations, sortby, compact)
+        _print_timer(io, timer, ∑t, ∑t, ∑b, ∑b, 0, name_length, allocations, sortby, compact)
     end
     print_header(io, Δt, Δb, ∑t, ∑b, name_length, false, allocations, linechars, compact, title)
 end
@@ -70,8 +70,8 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
     midrule       = linechars == :unicode ? "─" : "-"
     topbottomrule = linechars == :unicode ? "─" : "-"
     sec_ncalls = string(rpad("Section", name_length, " "), " ncalls  ")
-    time_headers = "   time    %tot" * (compact ? "" : "     avg")
-    alloc_headers = allocations ? ("  alloc    %tot" * (compact ? "" : "      avg")) : ""
+    time_headers = "   time    %tot" * (compact ? "" : "  %par     avg")
+    alloc_headers = allocations ? ("  alloc    %tot" * (compact ? "" : "  %par      avg")) : ""
     total_table_width = sum(textwidth.((sec_ncalls, time_headers, alloc_headers))) + 3
 
     # Just hardcoded shit to make things look nice
@@ -90,7 +90,7 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
         if compact
             time_header       = "      Time     "
         else
-            time_header       = "         Time          "
+            time_header       = "            Time             "
         end
 
         time_underline = midrule^textwidth(time_header)
@@ -98,7 +98,7 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
         if compact
             allocation_header       = "  Allocations  "
         else
-            allocation_header = "       Allocations      "
+            allocation_header = "          Allocations         "
         end
 
         alloc_underline = midrule^textwidth(allocation_header)
@@ -136,7 +136,7 @@ function print_header(io, Δt, Δb, ∑t, ∑b, name_length, header, allocations
     end
 end
 
-function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, ∑b::Integer, indent::Integer, name_length, allocations, sortby, compact)
+function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, tparent::Integer, ∑b::Integer, bparent::Integer, indent::Integer, name_length, allocations, sortby, compact)
     accum_data = to.accumulated_data
     t = accum_data.time
     b = accum_data.allocs
@@ -148,11 +148,13 @@ function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, ∑b::Integer, ind
 
     print(io, "   ", lpad(prettytime(t),        6, " "))
     print(io, "  ",  lpad(prettypercent(t, ∑t), 5, " "))
+    print(io, "  ",  lpad(prettypercent(t, tparent, decimal=false), 3, " "))
     !compact && print(io, "  ",  rpad(prettytime(t / nc), 6, " "))
 
     if allocations
     print(io, "   ", rpad(prettymemory(b),      9, " "))
     print(io, rpad(prettypercent(b, ∑b), 5, " "))
+    print(io, "  ", lpad(prettypercent(b, bparent, decimal=false), 3, " "))
     !compact && print(io, "  ",    lpad(prettymemory(b / nc), 5, " "))
     end
     print(io, "\n")
@@ -160,6 +162,6 @@ function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, ∑b::Integer, ind
     rev = !in(sortby, [:name, :firstexec])
     by(x) = sortf(x, sortby)
     for timer in sort!(collect(values(to.inner_timers)); rev = rev, by = by)
-        _print_timer(io, timer, ∑t, ∑b, indent + 2, name_length, allocations, sortby, compact)
+        _print_timer(io, timer, ∑t, t, ∑b, b, indent + 2, name_length, allocations, sortby, compact)
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -55,7 +55,7 @@ function prettymemory(b)
     return lpad(str, 7, " ")
 end
 
-function prettypercent(nominator, denominator)
+function prettypercent(nominator, denominator; decimal::Bool=true)
     value = nominator / denominator * 100
 
     if denominator == 0 && nominator == 0
@@ -63,9 +63,13 @@ function prettypercent(nominator, denominator)
     elseif denominator == 0
         str = "inf %"
     else
-        str = string(@sprintf("%.1f", value), "%")
+        if decimal
+            str = string(@sprintf("%.1f", value), "%")
+        else
+            str = string(@sprintf("%d", value), "%")
+        end
     end
-    return lpad(str, 6, " ")
+    return lpad(str, decimal ? 6 : 4, " ")
 end
 
 function prettycount(t::Integer)


### PR DESCRIPTION
Closes #192 

To keep the width additional minimal and to visually differentiate the different % columns this new column is just integer %'s which also makes sense because they will tend to be bigger % numbers.

```
julia> @timeit to "1" begin
               sleep(0.1)
               @timeit to "2" begin
                   sleep(0.1)
                   @timeit to "3" begin
                       sleep(0.1)
                   end
               end
           end

julia> to
────────────────────────────────────────────────────────────────────────────────
                              Time                          Allocations
                  ─────────────────────────────   ──────────────────────────────
Tot / % measured:         1.41s /  21.8%                 2.62MiB /   0.1%

Section   ncalls     time    %tot  %par     avg     alloc    %tot  %par      avg
────────────────────────────────────────────────────────────────────────────────
1              1    306ms  100.0%         306ms   3.19KiB  100.0%        3.19KiB
  2            1    204ms   66.7%   67%   204ms   1.64KiB   51.5%   51%  1.64KiB
    3          1    102ms   33.3%   50%   102ms      384B   11.8%   23%     384B
────────────────────────────────────────────────────────────────────────────────
```

@KristofferC what do you think? I can add tests & docs if you agree?