### PR TITLE
fix missing codecov for `@timeit`-defined functions, and add tests for issue 77

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,13 +15,11 @@ FlameGraphsExt = "FlameGraphs"
 [compat]
 ExprTools = "0.1.0"
 FlameGraphs = "1"
-Pkg = "1"
 julia = "1.10"
 
 [extras]
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test", "FlameGraphs", "Pkg"]
+test = ["Test", "FlameGraphs"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,19 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [weakdeps]
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 
+[extensions]
+FlameGraphsExt = "FlameGraphs"
+
 [compat]
 ExprTools = "0.1.0"
 FlameGraphs = "1"
+Pkg = "1"
 julia = "1.10"
 
 [extras]
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[extensions]
-FlameGraphsExt = "FlameGraphs"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [targets]
-test = ["Test", "FlameGraphs"]
+test = ["Test", "FlameGraphs", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [weakdeps]
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 
-[extensions]
-FlameGraphsExt = "FlameGraphs"
-
 [compat]
 ExprTools = "0.1.0"
 FlameGraphs = "1"
@@ -20,6 +17,9 @@ julia = "1.10"
 [extras]
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[extensions]
+FlameGraphsExt = "FlameGraphs"
 
 [targets]
 test = ["Test", "FlameGraphs"]

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -245,12 +245,8 @@ function _timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to::Unio
         $val
     end
 
-    # remove existing line numbers (#77) but add in the source for code coverage (#194)
-    timeit_block = Base.remove_linenums!(timeit_block)
-    pushfirst!(timeit_block.args, source)
-
-    if is_debug
-        return quote
+    result_expr = if is_debug
+        quote
             if $m.timeit_debug_enabled()
                 $timeit_block
             else
@@ -258,8 +254,14 @@ function _timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to::Unio
             end
         end
     else
-        return timeit_block
+        timeit_block
     end
+
+    # remove existing line numbers (#77) but add in the source for code coverage (#194)
+    result_expr = Base.remove_linenums!(result_expr)
+    pushfirst!(result_expr.args, source)
+
+    return result_expr
 end
 
 function timer_expr_func(source::LineNumberNode, m::Module, is_debug::Bool, to, expr::Expr, label=nothing)

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -246,15 +246,15 @@ function _timer_expr(m::Module, is_debug::Bool, to::Union{Symbol, Expr, TimerOut
     end
 
     if is_debug
-        return Base.remove_linenums!(quote
+        return quote
             if $m.timeit_debug_enabled()
                 $timeit_block
             else
                 $ex
             end
-        end)
+        end
     else
-        return Base.remove_linenums!(timeit_block)
+        return timeit_block
     end
 end
 

--- a/test/TestPkg/Project.toml
+++ b/test/TestPkg/Project.toml
@@ -1,0 +1,6 @@
+name = "TestPkg"
+uuid = "a1172fb3-f03b-46d1-aab3-7b5cb3128a7b"
+version = "0.1.0"
+
+[deps]
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"

--- a/test/TestPkg/src/TestPkg.jl
+++ b/test/TestPkg/src/TestPkg.jl
@@ -1,0 +1,11 @@
+module TestPkg
+
+using TimerOutputs
+
+const TIMER = TimerOutput()
+
+@timeit TIMER function abc()
+    1 + 1
+end
+
+end # module TestPkg

--- a/test/coverage_script.jl
+++ b/test/coverage_script.jl
@@ -1,0 +1,7 @@
+# entrypoint to TestPkg to invoke `abc`
+using Pkg, TimerOutputs
+
+Pkg.develop(; path=joinpath(pkgdir(TimerOutputs), "test", "TestPkg"))
+using TestPkg
+
+TestPkg.abc()

--- a/test/coverage_script.jl
+++ b/test/coverage_script.jl
@@ -1,7 +1,11 @@
 # entrypoint to TestPkg to invoke `abc`
-using Pkg, TimerOutputs
+using TimerOutputs
 
-Pkg.develop(; path=joinpath(pkgdir(TimerOutputs), "test", "TestPkg"))
-using TestPkg
+push!(LOAD_PATH, joinpath(pkgdir(TimerOutputs),  "test", "TestPkg"))
+try
+    using TestPkg
 
-TestPkg.abc()
+    TestPkg.abc()
+finally
+    pop!(LOAD_PATH)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -759,3 +759,5 @@ end
     flamegraph(to)
     flamegraph(to, crop_root=true)
 end
+
+include("test_coverage.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -760,4 +760,19 @@ end
     flamegraph(to, crop_root=true)
 end
 
+function foo_77(::Float64) end
+
+@testset "Stacktraces (#77)" begin
+    err = try
+        @timeit "foo_77" foo_77(1)
+    catch e
+        sprint(Base.display_error, e, catch_backtrace())
+    end
+
+    @test err isa AbstractString
+
+    # this err shouldn't have any stacktrace pointing into TimerOutputs.jl
+    @test !contains(err, "src/TimerOutput.jl:")
+end
+
 include("test_coverage.jl")

--- a/test/test_coverage.jl
+++ b/test/test_coverage.jl
@@ -1,0 +1,16 @@
+function find_cov_files()
+    pkg = joinpath(pkgdir(TimerOutputs), "test", "TestPkg")
+    return filter(endswith(".cov"), readdir(joinpath(pkg, "src"); join=true))
+end
+
+# remove existing coverage
+foreach(rm, find_cov_files())
+
+@testset "functions defined with `@timeit` macro generate code coverage" begin
+    @test isempty(find_cov_files())
+
+    script = joinpath(pkgdir(TimerOutputs), "test", "coverage_script.jl")
+    run(`julia --startup-file=no --project=$(pkgdir(TimerOutputs)) --check-bounds=yes --code-coverage $script`)
+
+    @test !isempty(find_cov_files())
+end


### PR DESCRIPTION
addresses https://github.com/KristofferC/TimerOutputs.jl/pull/164#issuecomment-2707710470

This PR adds tests for code-coverage from `@timeit` functions (c68902f), and for #77 (92fa0fb) and fixes them by removing line nums then re-inserting the `__source__` as mentioned in https://github.com/KristofferC/TimerOutputs.jl/pull/164#issuecomment-2669453104.

I did the commits incrementally with failing tests first to demonstrate the issues, so this PR should be squash-merged if it is to be merged.