### PR TITLE
Test suite: Don't assume that `julia` is in the PATH

### DIFF
--- a/test/test_coverage.jl
+++ b/test/test_coverage.jl
@@ -10,7 +10,8 @@ foreach(rm, find_cov_files())
     @test isempty(find_cov_files())
 
     script = joinpath(pkgdir(TimerOutputs), "test", "coverage_script.jl")
-    run(`julia --startup-file=no --project=$(pkgdir(TimerOutputs)) --check-bounds=yes --code-coverage $script`)
+    julia = Base.julia_cmd()[1]
+    run(`$julia --startup-file=no --project=$(pkgdir(TimerOutputs)) --check-bounds=yes --code-coverage $script`)
 
     @test !isempty(find_cov_files())
 end


### PR DESCRIPTION
The PkgEval.jl test suite runs this package's tests: https://github.com/JuliaCI/PkgEval.jl/blob/524847dc78c801a51a16ae7e747ebe19f8fc30a4/test/runtests.jl#L249-L249

Currently, PkgEval.jl CI is broken ([log](https://github.com/JuliaCI/PkgEval.jl/actions/runs/17701701262/job/50308213959?pr=288)) with:

```
functions defined with `@timeit` macro generate code coverage: Error During Test at /home/pkgeval/.julia/packages/TimerOutputs/L5q5K/test/test_coverage.jl:9
  Got exception outside of a @test
  IOError: could not spawn `julia --startup-file=no --project=/home/pkgeval/.julia/packages/TimerOutputs/L5q5K --check-bounds=yes --code-coverage /home/pkgeval/.julia/packages/TimerOutputs/L5q5K/test/coverage_script.jl`: no such file or directory (ENOENT)
  Stacktrace:
```

My guess is that `julia` is not in the PATH inside the container created by PkgEval.