### PR TITLE
Test suite: Skip the `test_coverage.jl` tests if `TIMEROUTPUTS_TEST_COVERAGE` is not set

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: 2
+          TIMEROUTPUTS_TEST_COVERAGE: true
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -804,4 +804,8 @@ function foo_77(::Float64) end
     @test !contains(err, "src/TimerOutput.jl:")
 end
 
-include("test_coverage.jl")
+# Skip the `test_coverage.jl` tests if TIMEROUTPUTS_TEST_COVERAGE is not set
+# The purpose of this is to fix CI on the PkgEval.jl repo
+if haskey(ENV, "TIMEROUTPUTS_TEST_COVERAGE")
+    include("test_coverage.jl")
+end


### PR DESCRIPTION
@maleadt It looks like https://github.com/JuliaCI/PkgEval.jl/pull/290 wasn't sufficient, because I'm still seeing TimerOutputs failures in the PkgEval.jl CI. So I think it might be easier to just completely skip `test_coverage.jl` in PkgEval CI.