### PR TITLE
Fix copy(TimeData) dropping the firstexec timestamp

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -8,7 +8,7 @@ mutable struct TimeData
     firstexec::Int64
 end
 TimeData(ncalls, time, allocs) = TimeData(ncalls, time, allocs, time)
-Base.copy(td::TimeData) = TimeData(td.ncalls, td.time, td.allocs)
+Base.copy(td::TimeData) = TimeData(td.ncalls, td.time, td.allocs, td.firstexec)
 TimeData() = TimeData(0, 0, 0, time_ns())
 
 function Base.:+(self::TimeData, other::TimeData)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,6 +618,12 @@ end
 
     table = sprint((io, to) -> show(io, to, sortby = :firstexec), to)
     @test match(r"aaaa", table).offset < match(r"bbbb", table).offset < match(r"cccc", table).offset
+
+    # copy and flatten must preserve the firstexec timestamp
+    td = TimerOutputs.TimeData(1, 2, 3, 4)
+    @test copy(td).firstexec == 4
+    fl = flatten(to)
+    @test fl["group"].accumulated_data.firstexec == to["group"].accumulated_data.firstexec
 end
 
 @static if isdefined(Threads, Symbol("@spawn"))


### PR DESCRIPTION
`Base.copy(td::TimeData)` called the 3-arg constructor, which reuses the accumulated `time` (a duration) as `firstexec` (a `time_ns()` timestamp). Since `flatten` copies every node, `show(flatten(to); sortby = :firstexec)` sorted on garbage values:

```julia
julia> td = to["outer"].accumulated_data; td.firstexec
95942655200671

julia> copy(td).firstexec   # before this fix
11484706                    # the accumulated time, not a timestamp
```

Pass `firstexec` through in `copy` and test that `flatten` preserves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)