### PR TITLE
Preserve user line numbers in @timeit function bodies

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -339,11 +339,26 @@ function _timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to::Unio
         timeit_block
     end
 
-    # remove existing line numbers (#77) but add in the source for code coverage (#194)
-    result_expr = Base.remove_linenums!(result_expr)
+    # remove wrapper line numbers (#77) but keep those of the user expression so
+    # stacktraces and coverage point into user code (#168), and add in the source
+    # for code coverage (#194)
+    remove_linenums_keep!(result_expr, ex)
     pushfirst!(result_expr.args, source)
 
     return result_expr
+end
+
+# Base.remove_linenums!, except the subtree `keep` is left untouched
+function remove_linenums_keep!(ex, keep)
+    if ex isa Expr && ex !== keep
+        if ex.head === :block || ex.head === :quote
+            filter!(x -> !(x isa LineNumberNode), ex.args)
+        end
+        for arg in ex.args
+            remove_linenums_keep!(arg, keep)
+        end
+    end
+    return ex
 end
 
 function timer_expr_func(source::LineNumberNode, m::Module, is_debug::Bool, to, expr::Expr, label = nothing)
@@ -353,12 +368,16 @@ function timer_expr_func(source::LineNumberNode, m::Module, is_debug::Bool, to, 
     label === nothing && (label = string(def[:name]))
 
     def[:body] = if is_debug
-        quote
+        body = def[:body]
+        wrapper = quote
             @inline function inner()
-                $(def[:body])
+                $body
             end
             $(_timer_expr(source, m, is_debug, to, label, :(inner())))
         end
+        remove_linenums_keep!(wrapper, body)
+        pushfirst!(wrapper.args, source)
+        wrapper
     else
         _timer_expr(source, m, is_debug, to, label, def[:body])
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -804,4 +804,38 @@ function foo_77(::Float64) end
     @test !contains(err, "src/TimerOutput.jl:")
 end
 
+@timeit "foo_168" function foo_168()
+    1 + 1
+
+    error("boom")
+end
+const foo_168_error_line = @__LINE__() - 2
+
+@timeit_debug "dbg_168" function dbg_168()
+    1 + 1
+
+    error("boom")
+end
+const dbg_168_error_line = @__LINE__() - 2
+
+@testset "Function body keeps line numbers (#168)" begin
+    st = try
+        foo_168()
+    catch
+        stacktrace(catch_backtrace())
+    end
+    i = findfirst(f -> f.func === :foo_168, st)
+    @test st[i].line == foo_168_error_line
+    @test endswith(String(st[i].file), "runtests.jl")
+
+    # debug variant: the user body lives in the `inner` closure, but the error
+    # line must still be visible in the trace
+    st = try
+        dbg_168()
+    catch
+        stacktrace(catch_backtrace())
+    end
+    @test any(f -> f.line == dbg_168_error_line && endswith(String(f.file), "runtests.jl"), st)
+end
+
 include("test_coverage.jl")


### PR DESCRIPTION
`_timer_expr` called `Base.remove_linenums!` on the whole result, which recursed into the spliced user expression. For `@timeit function ... end` this wiped every `LineNumberNode` in the body, so stacktraces and coverage attributed all body lines to the definition line:

```julia
@timeit to function multiline(x)   # line 1
    y = x + 1


    error("boom")                  # line 5 — reported as line 1
end
```

Replace it with `remove_linenums_keep!`, which strips the wrapper's line numbers (keeping the #77 behavior — no frames pointing into TimerOutputs) but leaves the user expression subtree untouched. The `@timeit_debug` funcdef wrapper gets the same treatment.

With this, per-line coverage of `@timeit`-wrapped bodies works (the `1 + 1` body line in TestPkg now gets its own count instead of collapsing into the def line), completing what #194 started.

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)