### PR TITLE
Don't throw when unwinding timed sections after reset_timer!

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -108,7 +108,8 @@ function Base.push!(to::TimerOutput, label::String)
     return timer.accumulated_data
 end
 
-Base.pop!(to::TimerOutput) = pop!(to.timer_stack)
+# The stack may be empty if `reset_timer!` was called inside a timed section (#172)
+Base.pop!(to::TimerOutput) = isempty(to.timer_stack) ? nothing : pop!(to.timer_stack)
 
 # Only sum the highest parents
 function totmeasured(to::TimerOutput)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -754,6 +754,22 @@ end
     end_timed_section!(to, section2)
 end
 
+@testset "reset_timer! inside a timed section (#172)" begin
+    to = TimerOutput()
+    @timeit to function foo_172(x)
+        reset_timer!(to)
+        x
+    end
+    @test foo_172(42) == 42
+
+    # nested sections unwinding after a reset must not throw either
+    @timeit to "outer" begin
+        @timeit to "inner" reset_timer!(to)
+    end
+    @timeit to "afterwards" 1 + 1
+    @test ncalls(to["afterwards"]) == 1
+end
+
 @testset "@timeit works with an empty label" begin
     to = TimerOutput()
     @timeit to "" begin end


### PR DESCRIPTION
Calling `reset_timer!` while inside a `@timeit` section empties `timer_stack`, so the section's `finally` block crashed:

```julia
to = TimerOutput()
@timeit to function foo(ode)
    reset_timer!(to)
end
foo(42)
# ERROR: ArgumentError: array must be non-empty
```

Make `pop!(::TimerOutput)` a no-op on an empty stack. The in-flight sections' timing writes go to their (now orphaned) `TimeData` objects, which is harmless, and sections started after the reset nest correctly under the root.

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)