### PR TITLE
Truncate section names by display width, not char count

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -52,15 +52,18 @@ function sortf(x, sortby)
     error("internal error")
 end
 
-# truncate string and add dots
+# truncate string to a display width of n and add dots
 function truncdots(str, n)
     textwidth(str) <= n && return str
     n <= 3 && return ""
     io = IOBuffer()
-    for (i, c) in enumerate(str)
-        i == n - 2 && (write(io, "..."); break)
+    width = 3 # for the dots
+    for c in str
+        width += textwidth(c)
+        width > n && break
         write(io, c)
     end
+    write(io, "...")
     return String(take!(io))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -760,6 +760,15 @@ end
     @test ncalls(to.inner_timers[""]) == 1
 end
 
+@testset "truncdots truncates by display width" begin
+    truncdots = TimerOutputs.truncdots
+    @test truncdots("abc", 10) == "abc"
+    @test truncdots("abcdefghijk", 10) == "abcdefg..."
+    @test truncdots("日本語の名前です", 10) == "日本語..."
+    @test textwidth(truncdots("日本語の名前です", 10)) <= 10
+    @test truncdots("日本語", 3) == ""
+end
+
 @testset "FlameGraphsExt" begin
     to = TimerOutput()
     begin


### PR DESCRIPTION
`truncdots` decided where to cut based on the character index, but the column budget is in display columns. For wide (e.g. CJK) names the truncated string overflowed:

```julia
julia> TimerOutputs.truncdots("日本語の名前です", 10) |> textwidth  # before
17
```

Accumulate `textwidth(c)` instead. ASCII behavior is unchanged (`"abcdefghijk"` at 10 still gives `"abcdefg..."`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)