### PR TITLE
Fix @timeit macro edge cases

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -249,20 +249,20 @@ end
 
 function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, ex::Expr)
     is_func_def(ex) && return timer_expr_func(source, m, is_debug, :($(TimerOutputs.DEFAULT_TIMER)), ex)
-    return _esc(_timer_expr(source, m, is_debug, :($(TimerOutputs).DEFAULT_TIMER)))
+    return timer_expr() # throws the usage error
 end
 
-function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, label_or_to, ex::Expr)
+function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, label_or_to, ex)
     is_func_def(ex) && return timer_expr_func(source, m, is_debug, label_or_to, ex)
     return _esc(_timer_expr(source, m, is_debug, :($(TimerOutputs).DEFAULT_TIMER), label_or_to))
 end
 
-function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, label::String, ex::Expr)
+function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, label::String, ex)
     is_func_def(ex) && return timer_expr_func(source, m, is_debug, :($(TimerOutputs).DEFAULT_TIMER), ex, label)
     return _esc(_timer_expr(source, m, is_debug, :($(TimerOutputs).DEFAULT_TIMER), label))
 end
 
-function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to, label, ex::Expr)
+function timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to, label, ex)
     is_func_def(ex) && return timer_expr_func(source, m, is_debug, to, ex, label)
     return _esc(_timer_expr(source, m, is_debug, to, label))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -760,6 +760,26 @@ end
     @test ncalls(to.inner_timers[""]) == 1
 end
 
+@testset "@timeit works with a non-Expr body" begin
+    to = TimerOutput()
+    x = 7
+    @test (@timeit to "lit" 42) == 42
+    @test (@timeit to "sym" x) == 7
+    @test (@timeit to "nothing" nothing) === nothing
+    @test ncalls(to["lit"]) == 1
+    @test ncalls(to["sym"]) == 1
+    @test ncalls(to["nothing"]) == 1
+    @test (@timeit "lit_216" 1) == 1
+    @test ncalls(DEFAULT_TIMER["lit_216"]) == 1
+end
+
+@testset "invalid @timeit usage throws ArgumentError" begin
+    # label-less non-function expression used to throw an internal MethodError
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit f(x)))
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit 42))
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit))
+end
+
 @testset "FlameGraphsExt" begin
     to = TimerOutput()
     begin


### PR DESCRIPTION
Two macro-expansion papercuts:

1. `@timeit begin ... end` (label-less, non-function-def) called a 4-arg `_timer_expr` method that doesn't exist, throwing an internal `MethodError` at expansion time. It now throws the friendly `ArgumentError("invalid macro usage for @timeit, ...")`.

2. `@timeit to "label" x` failed with "invalid macro usage" for any non-`Expr` body (symbols, literals, `nothing`), because every `timer_expr` method constrained the last argument to `ex::Expr`. This matters for generated code that splices values into `@timeit`. Arity already disambiguates the macro forms, so the constraint is relaxed:

```julia
julia> @timeit to "x" some_variable   # before: ERROR: LoadError: ArgumentError: invalid macro usage
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)