### PR TITLE
Print "-" instead of NaN for the avg column of zero-call sections

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -3,6 +3,8 @@
 ###################
 
 function prettytime(t)
+    # can be NaN if a section never finished (ncalls == 0 makes avg = 0/0)
+    isnan(t) && return lpad("-", 6, " ")
     if t < 1.0e3
         value, units = t, "ns"
     elseif t < 1.0e6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,6 +302,14 @@ end
         )
         @test prettytime(t) == str
     end
+    @test prettytime(NaN) == "     -"
+
+    # a section that never finished has ncalls == 0; avg must not print as NaN
+    let to_nan = TimerOutput()
+        begin_timed_section!(to_nan, "unfinished")
+        str = sprint(show, to_nan)
+        @test !occursin("NaN", str)
+    end
     for (b, str) in (
             (9.999 * 1024, "10.0KiB"), (99.999 * 1024, " 100KiB"),
             (9.999 * 1024^2, "10.0MiB"), (99.999 * 1024^2, " 100MiB"),


### PR DESCRIPTION
A section that was started but never finished (e.g. `begin_timed_section!` without `end_timed_section!`) has `ncalls == 0`, so the avg column computed `0/0` and rendered as `NaNh`:

```julia
to = TimerOutput()
begin_timed_section!(to, "unfinished")
show(stdout, to)
# unfinished   0   0.00ns  - %  NaNh   0.00B  - %  -
```

`prettymemory` already prints `"-"` for its NaN case; make `prettytime` do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)