### PR TITLE
Make copy(::TimerOutput) recursive instead of aliasing inner timers

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -54,10 +54,19 @@ mutable struct TimerOutput
 
 end
 
-Base.copy(to::TimerOutput) = TimerOutput(
-    copy(to.start_data), copy(to.accumulated_data), copy(to.inner_timers),
-    copy(to.timer_stack), to.name, to.flattened, to.enabled, to.totmeasured, "", nothing
+# copy of a single node, without children and with no active sections
+copy_node(to::TimerOutput) = TimerOutput(
+    copy(to.start_data), copy(to.accumulated_data), Dict{String, TimerOutput}(),
+    TimerOutput[], to.name, to.flattened, to.enabled, to.totmeasured, nothing, nothing
 )
+
+function Base.copy(to::TimerOutput)
+    toc = copy_node(to)
+    for (k, v) in to.inner_timers
+        toc.inner_timers[k] = copy(v)
+    end
+    return toc
+end
 
 const DEFAULT_TIMER = TimerOutput()
 const _timers = Dict{String, TimerOutput}("Default" => DEFAULT_TIMER)
@@ -442,8 +451,7 @@ function flatten(to::TimerOutput)
     for inner_timer in values(to.inner_timers)
         _flatten!(inner_timer, inner_timers)
     end
-    toc = copy(to)
-    return TimerOutput(toc.start_data, toc.accumulated_data, inner_timers, TimerOutput[], "Flattened", true, true, (t, b), "", to)
+    return TimerOutput(copy(to.start_data), copy(to.accumulated_data), inner_timers, TimerOutput[], "Flattened", true, true, (t, b), "", to)
 end
 
 
@@ -456,9 +464,7 @@ function _flatten!(to::TimerOutput, inner_timers::Dict{String, TimerOutput})
         timer = inner_timers[to.name]
         timer.accumulated_data += to.accumulated_data
     else
-        toc = copy(to)
-        toc.inner_timers = Dict{String, TimerOutput}()
-        inner_timers[toc.name] = toc
+        inner_timers[to.name] = copy_node(to)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -620,6 +620,18 @@ end
     @test match(r"aaaa", table).offset < match(r"bbbb", table).offset < match(r"cccc", table).offset
 end
 
+@testset "copy does not alias inner timers" begin
+    to = TimerOutput()
+    @timeit to "a" @timeit to "b" 1 + 1
+    c = copy(to)
+    @test haskey(c["a"], "b")
+    @timeit to "a" 1 + 1
+    @test ncalls(to["a"]) == 2
+    @test ncalls(c["a"]) == 1
+    c["a"].accumulated_data.ncalls = 99
+    @test ncalls(to["a"]) == 2
+end
+
 @static if isdefined(Threads, Symbol("@spawn"))
     @testset "merge at custom points during multithreading" begin
         to = TimerOutput()


### PR DESCRIPTION
`copy(to)` shallow-copied the `inner_timers` dict, so the copy shared every child node with the original:

```julia
julia> c = copy(to); c.inner_timers["x"] === to["x"]
true   # continuing to time on `to` also mutates the "copy"
```

`copy` now copies children recursively (the copy also starts with an empty `timer_stack` — snapshotting active sections into an independent tree isn't meaningful). `flatten` previously relied on `copy` + replacing the dict, which would turn O(n²) with a recursive copy, so it now uses a new `copy_node` helper that copies a single node without children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)