### PR TITLE
Micro cleanups: tuple membership tests, get! in get_timer

### DIFF
--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -70,10 +70,7 @@ If no timers are associated with `name`, a new `TimerOutput` will be created.
 """
 function get_timer(name::String)
     return lock(_timers_lock) do
-        if !haskey(_timers, name)
-            _timers[name] = TimerOutput(name)
-        end
-        _timers[name]
+        get!(() -> TimerOutput(name), _timers, name)
     end
 end
 
@@ -488,7 +485,7 @@ function complement!(to::TimerOutput)
     end
     tot_time = max(tot_time, 0)
     tot_allocs = max(tot_allocs, 0)
-    if !(to.name in ["root", "Flattened"])
+    if !(to.name in ("root", "Flattened"))
         name = string("~", to.name, "~")
         timer = TimerOutput(to.start_data, TimeData(max(1, to.accumulated_data.ncalls), tot_time, tot_allocs), Dict{String, TimerOutput}(), TimerOutput[], name, false, true, (tot_time, tot_allocs), to.name, to)
         to.inner_timers[name] = timer

--- a/src/show.jl
+++ b/src/show.jl
@@ -35,7 +35,7 @@ function Base.show(io::IO, to::TimerOutput; allocations::Bool = true, sortby::Sy
     name_length = max(9, max_name - max(0, requested_width - available_width))
 
     print_header(io, Δt, Δb, ∑t, ∑b, name_length, true, allocations, linechars, compact, title)
-    rev = !in(sortby, [:name, :firstexec])
+    rev = !in(sortby, (:name, :firstexec))
     by(x) = sortf(x, sortby)
     for timer in sort!(collect(values(to.inner_timers)); rev = rev, by = by)
         _print_timer(io, timer, ∑t, ∑b, 0, name_length, allocations, sortby, compact)
@@ -155,7 +155,7 @@ function _print_timer(io::IO, to::TimerOutput, ∑t::Integer, ∑b::Integer, ind
     end
     print(io, "\n")
 
-    rev = !in(sortby, [:name, :firstexec])
+    rev = !in(sortby, (:name, :firstexec))
     by(x) = sortf(x, sortby)
     for timer in sort!(collect(values(to.inner_timers)); rev = rev, by = by)
         _print_timer(io, timer, ∑t, ∑b, indent + 2, name_length, allocations, sortby, compact)


### PR DESCRIPTION
Three small cleanups, no behavior change:

- `sortby in [:name, :firstexec]` allocated a `Vector` per node while printing (it's in the recursive `_print_timer`); use a tuple.
- Same for `to.name in ["root", "Flattened"]` in `complement!`.
- `get_timer` did haskey + getindex (+ setindex!) under the lock; use `get!`. (The old comment in `push!` about `get!` allocating applied to the closure-capturing hot path on julia 1.3; `get_timer` is not hot and the package requires julia 1.10 now.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)