### PR TITLE
Docs: accessor docstrings, thread-safety section, current overhead number

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,9 +543,18 @@ To do that use `crop_root=true`
 ProfileView.view(flamegraph(to, crop_root=true))
 ```
 
+## Thread safety
+
+A `TimerOutput` instance (including the implicit default timer) is not thread-safe:
+timing sections on the same instance concurrently from multiple threads or tasks
+will race. Instead, use one `TimerOutput` per thread/task and combine them with
+`merge!` (which is protected by a lock), see the section on merging above.
+
 ## Overhead
 
-There is a small overhead in timing a section (0.25 μs) which means that this package is not suitable for measuring sections that finish very quickly.
+There is a small overhead in timing a section (~30 ns on a modern machine, dominated
+by reading the clock) which means that this package is not suitable for measuring
+sections that finish very quickly.
 For proper benchmarking you want to use a more suitable tool like [*BenchmarkTools*](https://github.com/JuliaCI/BenchmarkTools.jl).
 
 It is sometimes desireable to be able "turn on and off" the `@timeit` macro, for instance you may wish to instrument a package with `@timeit` macros, but then not deal with the overhead of the timings during normal package operation.

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -164,10 +164,39 @@ end
 #######
 
 # Accessors
+"""
+    TimerOutputs.ncalls(to::TimerOutput = DEFAULT_TIMER)
+
+The number of times the section was entered.
+"""
 ncalls(to::TimerOutput) = to.accumulated_data.ncalls
+
+"""
+    TimerOutputs.allocated(to::TimerOutput = DEFAULT_TIMER)
+
+The accumulated allocations in the section in bytes.
+"""
 allocated(to::TimerOutput) = to.accumulated_data.allocs
+
+"""
+    TimerOutputs.time(to::TimerOutput = DEFAULT_TIMER)
+
+The accumulated time in the section in nanoseconds.
+"""
 time(to::TimerOutput) = to.accumulated_data.time
+
+"""
+    TimerOutputs.totallocated(to::TimerOutput = DEFAULT_TIMER)
+
+Total allocated bytes over all sections directly under `to`.
+"""
 totallocated(to::TimerOutput) = totmeasured(to)[2]
+
+"""
+    TimerOutputs.tottime(to::TimerOutput = DEFAULT_TIMER)
+
+Total time in nanoseconds over all sections directly under `to`.
+"""
 tottime(to::TimerOutput) = totmeasured(to)[1]
 
 time() = time(DEFAULT_TIMER)
@@ -436,6 +465,12 @@ end
 Base.haskey(to::TimerOutput, name::String) = haskey(to.inner_timers, name)
 Base.getindex(to::TimerOutput, name::String) = to.inner_timers[name]
 
+"""
+    TimerOutputs.flatten(to::TimerOutput) -> TimerOutput
+
+Return a new `TimerOutput` where the data for all sections with identical
+labels, regardless of nesting level, is accumulated into one flat level.
+"""
 function flatten(to::TimerOutput)
     t, b = totmeasured(to)
     inner_timers = Dict{String, TimerOutput}()
@@ -474,6 +509,12 @@ end
 # Default function throws an error for the benefit of the user
 notimeit_expr(args...) = throw(ArgumentError("invalid macro usage for @notimeit, use as @notimeit [to] codeblock"))
 
+"""
+    TimerOutputs.complement!(to::TimerOutput = DEFAULT_TIMER)
+
+Add to each section a `~name~` subsection accounting for the time and
+allocations not covered by its subsections.
+"""
 complement!() = complement!(DEFAULT_TIMER)
 function complement!(to::TimerOutput)
     if length(to.inner_timers) == 0


### PR DESCRIPTION
- Docstrings for `TimerOutputs.ncalls`/`time`/`allocated`/`tottime`/`totallocated` (they were documented in the README's "Querying data" section but had no docstrings) and for `flatten`/`complement!`. Closes #171.
- New README "Thread safety" section stating that a `TimerOutput` instance is not thread-safe and pointing to the per-task + `merge!` pattern.
- The README claimed 0.25 μs overhead per section; measured today it is ~30 ns (Julia 1.12.6, Linux x86-64), dominated by the two `time_ns` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)