### PR TITLE
Add ConcurrentTimerOutput for timing in concurrent code

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: 2
+          JULIA_NUM_THREADS: 4
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -340,6 +340,50 @@ julia> show(to_2; compact = true, allocations = false, linechars = :ascii)
 
 The percentages showed are now relative to that "root".
 
+## Timing in multithreaded / concurrent code
+
+A `TimerOutput` must only be used from one task at a time — timing sections on the
+same instance concurrently from multiple threads or tasks will race and crash. For
+concurrent code, use a `ConcurrentTimerOutput` instead. It supports `@timeit`,
+`@timeit_debug`, `@notimeit`, `begin_timed_section!`/`end_timed_section!` and the
+functional `timeit` form, and can be freely shared between tasks:
+
+```julia
+const cto = ConcurrentTimerOutput()
+
+function work(i)
+    @timeit cto "work" begin
+        @timeit cto "step" step(i)
+    end
+end
+
+foreach(wait, [Threads.@spawn work(i) for i in 1:100])
+print_timer(cto)
+```
+
+Internally each task records into its own private timer tree (an extra cost of a
+few ns per section over a plain `TimerOutput`), and the trees are combined by
+section label whenever the timer is printed or queried. Semantics to be aware of:
+
+* The time reported for a section is the **sum of the wall clock time every task
+  spent inside it**, including time where a task was waiting or descheduled. With
+  parallelism the measured percentage therefore exceeds 100% — e.g. 8 continuously
+  busy tasks approach 800% of the elapsed time.
+* Queries (`getindex`, `TimerOutputs.ncalls`, ...) and `TimerOutput(cto)` return
+  detached snapshot copies. Snapshots taken while sections are in flight are
+  approximately consistent; they are exact once the timed tasks have finished.
+* Sections that are in flight while `reset_timer!` is called may or may not be
+  counted.
+* For a flamegraph, convert to a snapshot first: `flamegraph(TimerOutput(cto))`
+  (note that section spans from different tasks overlap under concurrency).
+
+Reporting on-CPU time instead of wall time (via `Base.Experimental.task_running_time_ns`,
+Julia 1.12+) may be added as an opt-in in the future.
+
+Alternatively, the manual pattern from the previous section — one plain
+`TimerOutput` per task, combined with `merge!` at a join point — remains fully
+supported and has zero extra cost in the timed sections.
+
 ## Querying data
 
 The (unexported) functions `ncalls`, `time`, `allocated` give the accumulated data for a section.

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -108,7 +108,8 @@ function Base.push!(to::TimerOutput, label::String)
     return timer.accumulated_data
 end
 
-Base.pop!(to::TimerOutput) = pop!(to.timer_stack)
+# The stack may be empty if `reset_timer!` was called inside a timed section (#172)
+Base.pop!(to::TimerOutput) = isempty(to.timer_stack) ? nothing : pop!(to.timer_stack)
 
 # Only sum the highest parents
 function totmeasured(to::TimerOutput)

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -164,6 +164,10 @@ end
 # API #
 #######
 
+# What the @timeit macro checks; the generic fallback keeps any timer-like
+# object with an `enabled` field working
+@inline isenabled(x) = x.enabled
+
 # Accessors
 ncalls(to::TimerOutput) = to.accumulated_data.ncalls
 allocated(to::TimerOutput) = to.accumulated_data.allocs
@@ -273,7 +277,7 @@ function _timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to::Unio
     @gensym local_to enabled accumulated_data b₀ t₀ val
     timeit_block = quote
         $local_to = $to
-        $enabled = $local_to.enabled
+        $enabled = $(isenabled)($local_to)
         if $enabled
             $accumulated_data = $(push!)($local_to, $label)
         end
@@ -307,7 +311,7 @@ function _timer_expr(source::LineNumberNode, m::Module, is_debug::Bool, to::Unio
     @gensym local_to enabled accumulated_data b₀ t₀ val
     timeit_block = quote
         $local_to = $to
-        $enabled = $local_to.enabled
+        $enabled = $(isenabled)($local_to)
         if $enabled
             $accumulated_data = $(push!)($local_to, $label)
         end
@@ -504,7 +508,7 @@ notimeit_expr(ex::Expr) = notimeit_expr(:($(TimerOutputs.DEFAULT_TIMER)), ex)
 function notimeit_expr(to, ex::Expr)
     return quote
         local to = $(esc(to))
-        local enabled = to.enabled
+        local enabled = $(isenabled)(to)
         $(disable_timer!)(to)
         local val
         $(

--- a/src/TimerOutput.jl
+++ b/src/TimerOutput.jl
@@ -8,7 +8,7 @@ mutable struct TimeData
     firstexec::Int64
 end
 TimeData(ncalls, time, allocs) = TimeData(ncalls, time, allocs, time)
-Base.copy(td::TimeData) = TimeData(td.ncalls, td.time, td.allocs)
+Base.copy(td::TimeData) = TimeData(td.ncalls, td.time, td.allocs, td.firstexec)
 TimeData() = TimeData(0, 0, 0, time_ns())
 
 function Base.:+(self::TimeData, other::TimeData)

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -3,8 +3,8 @@ module TimerOutputs
 using ExprTools
 
 import Base: show, time_ns
-export TimerOutput, @timeit, @timeit_debug, reset_timer!, print_timer, timeit,
-    enable_timer!, disable_timer!, @notimeit, get_timer,
+export TimerOutput, ConcurrentTimerOutput, @timeit, @timeit_debug, reset_timer!,
+    print_timer, timeit, enable_timer!, disable_timer!, @notimeit, get_timer,
     begin_timed_section!, end_timed_section!
 
 
@@ -20,6 +20,7 @@ using Printf
 include("TimerOutput.jl")
 include("show.jl")
 include("utilities.jl")
+include("threaded.jl")
 
 include("compile.jl")
 _precompile_()

--- a/src/compile.jl
+++ b/src/compile.jl
@@ -2,6 +2,9 @@
 let
     to = TimerOutput()
     @timeit to "1" string(1)
+    cto = ConcurrentTimerOutput()
+    @timeit cto "1" string(1)
+    sprint(show, cto)
 end
 
 function _precompile_()
@@ -14,5 +17,10 @@ function _precompile_()
     @assert Base.precompile(Tuple{typeof(enable_timer!), TimerOutput})
     @assert Base.precompile(Tuple{typeof(complement!), TimerOutput})
     @assert Base.precompile(Tuple{typeof(do_accumulate!), TimeData, UInt64, Int64})
+    @assert Base.precompile(Tuple{typeof(push!), ConcurrentTimerOutput, String})
+    @assert Base.precompile(Tuple{typeof(pop!), ConcurrentTimerOutput})
+    @assert Base.precompile(Tuple{typeof(register_task_timer!), ConcurrentTimerOutput})
+    @assert Base.precompile(Tuple{typeof(merged), ConcurrentTimerOutput})
+    @assert Base.precompile(Tuple{typeof(reset_timer!), ConcurrentTimerOutput})
     return @assert Base.precompile(Tuple{Type{TimerOutput}, String})
 end

--- a/src/threaded.jl
+++ b/src/threaded.jl
@@ -1,0 +1,226 @@
+#########################
+# ConcurrentTimerOutput #
+#########################
+
+"""
+    ConcurrentTimerOutput()
+
+A timer that, unlike `TimerOutput`, can be used from multiple tasks (and
+therefore threads) concurrently. Each task transparently records into its own
+private timer tree; the trees are combined by label whenever the timer is
+displayed or queried.
+
+Semantics: the time reported for a section is the sum of the wall clock time
+every task spent inside it (including time where the task was not scheduled),
+so with parallelism the measured percentage can exceed 100%. Queries like
+`getindex` and `TimerOutput(cto)` return detached snapshot copies; snapshots
+taken while sections are in flight are approximately consistent and become
+exact once the tasks quiesce.
+"""
+mutable struct ConcurrentTimerOutput
+    @atomic enabled::Bool
+    @atomic generation::Int # bumped by reset_timer!
+    const lock::ReentrantLock
+    const task_timers::Vector{Tuple{WeakRef, TimerOutput}} # (task, its private tree); guarded by lock
+    archive::TimerOutput # merged trees of finished tasks; canonical start_data; guarded by lock
+end
+
+function ConcurrentTimerOutput()
+    return ConcurrentTimerOutput(true, 0, ReentrantLock(), Tuple{WeakRef, TimerOutput}[], TimerOutput())
+end
+
+isenabled(cto::ConcurrentTimerOutput) = @atomic :monotonic cto.enabled
+enable_timer!(cto::ConcurrentTimerOutput) = @atomic cto.enabled = true
+disable_timer!(cto::ConcurrentTimerOutput) = @atomic cto.enabled = false
+
+# The value stored in task local storage, keyed by the ConcurrentTimerOutput
+struct TaskTimerEntry
+    generation::Int
+    timer::TimerOutput
+end
+
+# Hot path: fetch the calling task's private timer (~3 ns)
+@inline function task_timer(cto::ConcurrentTimerOutput)
+    entry = get(task_local_storage(), cto, nothing)
+    if entry isa TaskTimerEntry && entry.generation == (@atomic :monotonic cto.generation)
+        return entry.timer
+    end
+    return register_task_timer!(cto)
+end
+
+# Slow path, once per task (and generation). Everything happens under the lock
+# so that a timer can never be registered under a stale generation.
+@noinline function register_task_timer!(cto::ConcurrentTimerOutput)
+    return lock(cto.lock) do
+        timer = TimerOutput()
+        push!(cto.task_timers, (WeakRef(current_task()), timer))
+        task_local_storage()[cto] = TaskTimerEntry(@atomic(cto.generation), timer)
+        timer
+    end
+end
+
+# Inserting a new label must take the lock: `merged` may be iterating this
+# task's inner_timers from another task while we mutate the Dict. Runs once
+# per distinct label per task. A function instead of a `lock() do` closure in
+# push! to avoid boxing `timer` in the hot path there.
+@noinline function locked_insert!(cto::ConcurrentTimerOutput, parent::TimerOutput, label::String)
+    timer = TimerOutput(label)
+    lock(cto.lock)
+    try
+        parent.inner_timers[label] = timer
+    finally
+        unlock(cto.lock)
+    end
+    return timer
+end
+
+# Same as push!(::TimerOutput, label) except for the locked insert of new
+# labels. The steady state paths are lock-free.
+function Base.push!(cto::ConcurrentTimerOutput, label::String)
+    to = task_timer(cto)
+    if length(to.timer_stack) == 0 # Root section
+        current_timer = to
+    else # Not a root section
+        current_timer = to.timer_stack[end]
+    end
+    # Fast path
+    if current_timer.prev_timer_label == label
+        timer = current_timer.prev_timer
+    else
+        maybe_timer = get(current_timer.inner_timers, label, nothing)
+        if maybe_timer === nothing
+            timer = locked_insert!(cto, current_timer, label)
+        else
+            timer = maybe_timer
+        end
+    end
+    timer = timer::TimerOutput
+    current_timer.prev_timer_label = label
+    current_timer.prev_timer = timer
+
+    push!(to.timer_stack, timer)
+    return timer.accumulated_data
+end
+
+# Deliberately does not check the generation: if reset_timer! happened while a
+# section was in flight, its finally block must still unwind the (orphaned)
+# tree it started in instead of registering a fresh one.
+function Base.pop!(cto::ConcurrentTimerOutput)
+    entry = get(task_local_storage(), cto, nothing)
+    entry isa TaskTimerEntry || return nothing
+    return pop!(entry.timer)
+end
+
+function reset_timer!(cto::ConcurrentTimerOutput)
+    lock(cto.lock) do
+        @atomic cto.generation += 1
+        empty!(cto.task_timers)
+        cto.archive = TimerOutput()
+    end
+    return cto
+end
+
+# Copy of the parts of the tree that `merged` needs: name, accumulated data
+# and children. Unlike `copy`/`deepcopy` this does not touch timer_stack or
+# the prev_timer cache, which the owning task may be mutating.
+function _snapshot(to::TimerOutput)
+    acc = to.accumulated_data
+    inner_timers = Dict{String, TimerOutput}()
+    for (k, v) in to.inner_timers
+        inner_timers[k] = _snapshot(v)
+    end
+    return TimerOutput(
+        copy(to.start_data), TimeData(acc.ncalls, acc.time, acc.allocs, acc.firstexec),
+        inner_timers, TimerOutput[], to.name, to.flattened, to.enabled, to.totmeasured,
+        nothing, nothing
+    )
+end
+
+"""
+    TimerOutput(cto::ConcurrentTimerOutput) -> TimerOutput
+
+Combine the per-task timer trees of `cto` into a single detached `TimerOutput`
+snapshot, merging sections with the same label and nesting.
+"""
+TimerOutput(cto::ConcurrentTimerOutput) = merged(cto)
+
+function merged(cto::ConcurrentTimerOutput)
+    return lock(cto.lock) do
+        # fold the trees of finished tasks into the archive and drop them,
+        # bounding memory when many short-lived tasks are timed
+        filter!(cto.task_timers) do (ref, timer)
+            task = ref.value
+            if task === nothing || istaskdone(task::Task)
+                cto.archive.accumulated_data += timer.accumulated_data
+                _merge(cto.archive.inner_timers, timer.inner_timers)
+                false
+            else
+                true
+            end
+        end
+        result = _snapshot(cto.archive) # carries start_data from creation/reset
+        for (_, timer) in cto.task_timers
+            snap = _snapshot(timer)
+            result.accumulated_data += snap.accumulated_data
+            _merge(result.inner_timers, snap.inner_timers)
+        end
+        result
+    end
+end
+
+# Sections started manually
+function begin_timed_section!(cto::ConcurrentTimerOutput, label::String)
+    data = push!(cto, label)
+    b₀ = gc_bytes()
+    t₀ = time_ns()
+    return SectionTimeData(label, data, b₀, t₀)
+end
+
+function end_timed_section!(cto::ConcurrentTimerOutput, section::SectionTimeData)
+    section.data.time += time_ns() - section.time_start
+    section.data.allocs += gc_bytes() - section.allocs_start
+    section.data.ncalls += 1
+    return pop!(cto)
+end
+
+function timeit(f::Function, cto::ConcurrentTimerOutput, label::String)
+    section = begin_timed_section!(cto, label)
+    local val
+    try
+        val = f()
+    finally
+        end_timed_section!(cto, section)
+    end
+    return val
+end
+
+# Queries and display all work on a merged snapshot
+ncalls(cto::ConcurrentTimerOutput) = ncalls(merged(cto))
+allocated(cto::ConcurrentTimerOutput) = allocated(merged(cto))
+time(cto::ConcurrentTimerOutput) = time(merged(cto))
+totallocated(cto::ConcurrentTimerOutput) = totallocated(merged(cto))
+tottime(cto::ConcurrentTimerOutput) = tottime(merged(cto))
+todict(cto::ConcurrentTimerOutput) = todict(merged(cto))
+flatten(cto::ConcurrentTimerOutput) = flatten(merged(cto))
+Base.haskey(cto::ConcurrentTimerOutput, name::String) = haskey(merged(cto), name)
+Base.getindex(cto::ConcurrentTimerOutput, name::String) = merged(cto)[name]
+
+function complement!(::ConcurrentTimerOutput)
+    throw(ArgumentError("complement! mutates a timer in place; use complement!(TimerOutput(cto)) on a snapshot"))
+end
+
+Base.merge!(self::TimerOutput, cto::ConcurrentTimerOutput; kwargs...) = merge!(self, merged(cto); kwargs...)
+function Base.merge!(cto::ConcurrentTimerOutput, others::TimerOutput...)
+    lock(cto.lock) do
+        for other in others
+            cto.archive.accumulated_data += other.accumulated_data
+            _merge(cto.archive.inner_timers, other.inner_timers)
+        end
+    end
+    return cto
+end
+
+Base.show(cto::ConcurrentTimerOutput; kwargs...) = show(stdout, cto; kwargs...)
+Base.show(io::IO, cto::ConcurrentTimerOutput; kwargs...) = show(io, merged(cto); kwargs...)
+print_timer(cto::ConcurrentTimerOutput; kwargs...) = print_timer(stdout, cto; kwargs...)
+print_timer(io::IO, cto::ConcurrentTimerOutput; kwargs...) = (show(io, cto; kwargs...); println(io))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -826,4 +826,131 @@ function foo_77(::Float64) end
     @test !contains(err, "src/TimerOutput.jl:")
 end
 
+const DEBUG_CTO = ConcurrentTimerOutput()
+@timeit_debug DEBUG_CTO function timeit_debug_cto()
+    1 + 1
+end
+
+@testset "ConcurrentTimerOutput" begin
+    @testset "single task parity" begin
+        cto = ConcurrentTimerOutput()
+        @timeit cto "outer" begin
+            @timeit cto "inner" sleep(0.01)
+            @timeit cto "inner" sleep(0.01)
+        end
+        m = TimerOutput(cto)
+        @test ncalls(m["outer"]) == 1
+        @test ncalls(m["outer"]["inner"]) == 2
+        @test TimerOutputs.time(m["outer"]) >= 2 * 10^7 # 2 * 10 ms in ns
+    end
+
+    @testset "invariants under @spawn" begin
+        cto = ConcurrentTimerOutput()
+        N, M = 32, 500
+        function spawn_worker(cto, i, M)
+            return Threads.@spawn for j in 1:M
+                @timeit cto "work" begin
+                    @timeit cto "inner" (j % 7 == 0 ? yield() : nothing)
+                    @timeit cto "task $i" (1 + 1)
+                end
+            end
+        end
+        tasks = [spawn_worker(cto, i, M) for i in 1:N]
+        foreach(wait, tasks)
+        m = TimerOutput(cto)
+        @test ncalls(m["work"]) == N * M
+        @test ncalls(m["work"]["inner"]) == N * M
+        for i in 1:N
+            @test ncalls(m["work"]["task $i"]) == M
+        end
+        # all tasks finished: trees are folded into the archive, no double counting
+        @test isempty(cto.task_timers)
+        @test ncalls(TimerOutput(cto)["work"]) == N * M
+        GC.gc()
+        @test ncalls(TimerOutput(cto)["work"]) == N * M
+    end
+
+    @testset "printing while tasks are running" begin
+        cto = ConcurrentTimerOutput()
+        stop = Threads.Atomic{Bool}(false)
+        function spawn_load(cto, stop)
+            return Threads.@spawn begin
+                k = 0
+                while !stop[]
+                    k += 1
+                    @timeit cto "label $(k % 50)" (k % 11 == 0 ? yield() : nothing)
+                end
+            end
+        end
+        workers = [spawn_load(cto, stop) for _ in 1:4]
+        for _ in 1:200
+            print_timer(devnull, cto)
+        end
+        stop[] = true
+        foreach(wait, workers)
+        @test true # no throw above
+    end
+
+    @testset "reset during in-flight section" begin
+        cto = ConcurrentTimerOutput()
+        c1, c2 = Channel{Nothing}(1), Channel{Nothing}(1)
+        t = Threads.@spawn begin
+            @timeit cto "flight" begin
+                put!(c1, nothing) # signal: inside the section
+                take!(c2)         # wait until the reset happened
+            end
+            @timeit cto "after" 1 + 1
+        end
+        take!(c1)
+        reset_timer!(cto)
+        put!(c2, nothing)
+        wait(t)
+        m = TimerOutput(cto)
+        @test !haskey(m, "flight")
+        @test ncalls(m["after"]) == 1
+    end
+
+    @testset "enable/disable and @notimeit" begin
+        cto = ConcurrentTimerOutput()
+        disable_timer!(cto)
+        @timeit cto "off" 1 + 1
+        enable_timer!(cto)
+        @timeit cto "on" 1 + 1
+        @notimeit cto (@timeit cto "notimeit" 1 + 1)
+        @test !haskey(cto, "off")
+        @test haskey(cto, "on")
+        @test !haskey(cto, "notimeit")
+        @test TimerOutputs.isenabled(cto)
+    end
+
+    @testset "API delegation" begin
+        cto = ConcurrentTimerOutput()
+        @test timeit(() -> 42, cto, "functional") == 42
+        section = begin_timed_section!(cto, "manual")
+        end_timed_section!(cto, section)
+        @test ncalls(cto["manual"]) == 1
+        @test flatten(cto) isa TimerOutput
+        @test todict(cto)["inner_timers"]["manual"]["n_calls"] == 1
+        @test TimerOutputs.tottime(cto) >= 0
+        @test TimerOutputs.totallocated(cto) >= 0
+        merged_into = merge!(TimerOutput(), cto)
+        @test ncalls(merged_into["manual"]) == 1
+        to = TimerOutput()
+        @timeit to "external" 1 + 1
+        merge!(cto, to)
+        @test ncalls(cto["external"]) == 1
+        @test_throws ArgumentError TimerOutputs.complement!(cto)
+        sprint((io, x) -> show(io, x; sortby = :firstexec), cto)
+        # getindex returns a detached snapshot
+        snap = cto["manual"]
+        snap.accumulated_data.ncalls = 999
+        @test ncalls(cto["manual"]) == 1
+    end
+
+    @testset "@timeit_debug with ConcurrentTimerOutput" begin
+        timeit_debug_cto() # debug timings for Main are enabled further up in this file
+        @test ncalls(DEBUG_CTO["timeit_debug_cto"]) == 1
+    end
+end
+
 include("test_coverage.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -760,6 +760,22 @@ end
     end_timed_section!(to, section2)
 end
 
+@testset "reset_timer! inside a timed section (#172)" begin
+    to = TimerOutput()
+    @timeit to function foo_172(x)
+        reset_timer!(to)
+        x
+    end
+    @test foo_172(42) == 42
+
+    # nested sections unwinding after a reset must not throw either
+    @timeit to "outer" begin
+        @timeit to "inner" reset_timer!(to)
+    end
+    @timeit to "afterwards" 1 + 1
+    @test ncalls(to["afterwards"]) == 1
+end
+
 @testset "@timeit works with an empty label" begin
     to = TimerOutput()
     @timeit to "" begin end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,6 +618,12 @@ end
 
     table = sprint((io, to) -> show(io, to, sortby = :firstexec), to)
     @test match(r"aaaa", table).offset < match(r"bbbb", table).offset < match(r"cccc", table).offset
+
+    # copy and flatten must preserve the firstexec timestamp
+    td = TimerOutputs.TimeData(1, 2, 3, 4)
+    @test copy(td).firstexec == 4
+    fl = flatten(to)
+    @test fl["group"].accumulated_data.firstexec == to["group"].accumulated_data.firstexec
 end
 
 @static if isdefined(Threads, Symbol("@spawn"))


### PR DESCRIPTION
Implements task/thread-safe timing (closes #72).

```julia
const cto = ConcurrentTimerOutput()
work(i) = @timeit cto "work" @timeit cto "step" step(i)
foreach(wait, [Threads.@spawn work(i) for i in 1:100])
print_timer(cto)
```

## Design

- Each task lazily gets its own **private `TimerOutput` tree**, stored in `task_local_storage` keyed by the `ConcurrentTimerOutput` (measured lookup: ~3 ns). The hot path (`push!`/`do_accumulate!`/`pop!`) runs entirely on task-private data — no locks or atomics — except that inserting a *new label* into a tree takes the instance lock, since `merged` may be snapshotting that `Dict` from another task. That branch runs once per distinct label per task.
- A lock-protected registry of `(WeakRef(task), tree)` pairs feeds `merged(cto)`, which combines the trees by label into a detached `TimerOutput` snapshot (public as `TimerOutput(cto)`). Trees of finished tasks are folded into an archive and dropped, bounding memory when many short-lived tasks are timed.
- `reset_timer!` bumps an atomic generation; in-flight sections unwind into their orphaned trees (same semantics as #208 for the plain timer). `pop!` is deliberately generation-blind so enclosing sections stay balanced.
- The `@timeit` macro now checks `isenabled(to)` instead of reading `.enabled` directly (inlines to the identical `getfield` for `TimerOutput`; a duck-typed fallback keeps any third-party timer-likes working). This is also what makes `@timeit_debug cto` and `@notimeit cto` work without further changes.
- **Semantics** (documented in a new README section): per-section time is the summed wall-clock time of all tasks inside it, so "% measured" can exceed 100% under parallelism; queries return approximately-consistent snapshots while sections are in flight, exact once tasks quiesce. On-CPU time via Julia 1.12 task metrics is noted as possible future opt-in.

## Numbers (Julia 1.12, linux x86-64)

| | ns/section |
|---|---|
| plain `@timeit`, 8 threads | 125.2 |
| `ConcurrentTimerOutput`, single task, 8 threads | 127.9 (0 allocs) |
| 8 tasks hammering one `cto` (16M sections) | 101.8, exact ncalls |

(Both are dominated by `gc_bytes()` at 8 threads — `jl_gc_get_total_bytes` iterates every thread's counter, ~50 ns at 8 threads vs ~3 ns single-threaded. That's pre-existing and affects the plain timer equally; will file separately.)

The issue #72 reproducer shape (many `@spawn`ed tasks timing on one shared timer, which crashes a plain `TimerOutput` with `UndefRefError`) runs green with exact counts — it's part of the new testset, along with printing-while-running stress, reset/disable mid-flight, dead-task folding, and an API delegation battery. CI now runs with `JULIA_NUM_THREADS: 4`.

**Note:** the first two commits are #206 and #208, which this builds on (empty-stack-safe `pop!`, `firstexec`-preserving `copy`). They'll rebase away once those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoBma35mwR9EeEomy7MbaY