### PR TITLE
Add "heat" bar columns to the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ internals may need updating (see "Internal changes" below).
 * **New table layout** (now built on PrettyTables.jl): tree guides (`├─`, `└─`)
   instead of plain indentation, and an optional `%par` column showing each
   section's share of its enclosing section (`columns = [..., :time_par]`).
+* **Heat bars**: the default table shows a small bar per section visualizing
+  its share of the total time / allocations, colored from blue (cheap) to red
+  (expensive) in color-capable terminals. Displaying a subsection rescales the
+  bars to that subsection's total. Hide them with `bars = false` (`compact =
+  true` also drops them), or select them explicitly through the `columns`
+  keyword (`:time_bar`, `:allocs_bar`).
 * **Column selection**: `print_timer(to; columns = [:ncalls, :time, :time_pct])`
   picks exactly which columns to show, in order; `allocations` and `compact`
   remain as shorthands.

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ See the [changelog](CHANGELOG.md) for what is new in version 0.5.30.
 An example of the output (used in a finite element simulation) is shown below
 
 ```
-──────────────────────────────────────────────────────────────────────────────────
-                                        Time                   Allocations
-                               ──────────────────────    ────────────────────────
-      Tot / % measured:            6.89s / 97.8%             5.20GiB / 84.6%
- ────────────────────────────  ──────────────────────    ────────────────────────
- Section               ncalls    time    %tot     avg      alloc    %tot      avg
-──────────────────────────────────────────────────────────────────────────────────
- assemble                   6   3.27s   48.5%   545ms    3.65GiB   82.7%   623MiB
- └─ inner assemble       240k   1.92s   28.5%  8.00μs    3.14GiB   71.1%  13.7KiB
- linear solve               5   2.73s   40.5%   546ms     108MiB    2.4%  21.6MiB
- create sparse matrix       6   658ms    9.8%   110ms     662MiB   14.6%   110MiB
- export                     1  78.4ms    1.2%  78.4ms    13.1MiB    0.3%  13.1MiB
-──────────────────────────────────────────────────────────────────────────────────
+──────────────────────────────────────────────────────────────────────────────────────────────────────
+                                             Time                             Allocations
+                               ────────────────────────────────    ──────────────────────────────────
+      Tot / % measured:                 6.89s / 97.8%                       5.20GiB / 84.9%
+ ────────────────────────────  ────────────────────────────────    ──────────────────────────────────
+ Section               ncalls    time    %tot     avg                alloc    %tot      avg
+──────────────────────────────────────────────────────────────────────────────────────────────────────
+ assemble                   6   3.27s   48.5%   545ms  ███▉        3.65GiB   82.7%   623MiB  ██████▋
+ └─ inner assemble       240k   1.92s   28.5%  8.00μs  ██▎         3.14GiB   71.1%  13.7KiB  █████▊
+ linear solve               5   2.73s   40.5%   546ms  ███▎         108MiB    2.4%  21.6MiB  ▎
+ create sparse matrix       6   658ms    9.8%   110ms  ▊            662MiB   14.6%   110MiB  █▏
+ export                     1  78.4ms    1.2%  78.4ms  ▏           13.1MiB    0.3%  13.1MiB
+──────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 
 The `Tot / % measured` row shows the total (wall) time passed and allocations made since the start of the timer as well as
@@ -38,6 +38,8 @@ The following lines shows data for all the timed sections.
 The section label is shown first followed by the number of calls made to that section.
 Finally, the total time elapsed or allocations made in that section are shown together with the
 percentage of the total in that section and the average (time / allocations per call).
+The bar columns visualize each section's share of the total; in color-capable
+terminals they are colored from blue (cheap) to red (expensive).
 A `%par` column showing the percentage of the enclosing section is available through the
 `columns` printing option, see below.
 
@@ -135,29 +137,29 @@ spent in each section since `to` was created as well as averages (per call).
 Similar information is available for allocations:
 
 ```
-──────────────────────────────────────────────────────────────────────────────────────────
-                                                Time                   Allocations
-                                       ──────────────────────    ────────────────────────
-          Tot / % measured:                4.22s / 67.2%              103MiB / 81.7%
- ────────────────────────────────────  ──────────────────────    ────────────────────────
- Section                       ncalls    time    %tot     avg      alloc    %tot      avg
-──────────────────────────────────────────────────────────────────────────────────────────
- sleep                            101   1.14s   40.2%  11.3ms    17.1KiB    0.0%     173B
- nest 2                             1   703ms   24.8%   703ms       496B    0.0%     496B
- ├─ level 2.2                       1   402ms   14.2%   402ms       112B    0.0%     112B
- └─ level 2.1                       1   301ms   10.6%   301ms       112B    0.0%     112B
- throwing                           1   502ms   17.7%   502ms       512B    0.0%     512B
- nest 1                             1   396ms   14.0%   396ms       944B    0.0%     944B
- ├─ level 2.2                       1   201ms    7.1%   201ms       112B    0.0%     112B
- └─ level 2.1                       3  93.4ms    3.3%  31.1ms       336B    0.0%     112B
- randoms                            1  95.1ms    3.4%  95.1ms    84.2MiB  100.0%  84.2MiB
- line_profile @ example.jl          1  3.87μs    0.0%  3.87μs       432B    0.0%     432B
- ├─ L5: for i = 1:n                 1   558ns    0.0%   558ns       160B    0.0%     160B
- │  └─ L6: x += i                  10   105ns    0.0%  10.5ns      0.00B    0.0%    0.00B
- └─ L4: x = 0                       1  13.0ns    0.0%  13.0ns      0.00B    0.0%    0.00B
- funcdef                            1  15.0ns    0.0%  15.0ns      0.00B    0.0%    0.00B
- foo                                1  14.0ns    0.0%  14.0ns      0.00B    0.0%    0.00B
-──────────────────────────────────────────────────────────────────────────────────────────
+───────────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                  Time                             Allocations
+                                    ────────────────────────────────    ──────────────────────────────────
+         Tot / % measured:                   4.38s / 63.9%                        113MiB / 68.3%
+ ─────────────────────────────────  ────────────────────────────────    ──────────────────────────────────
+ Section                    ncalls    time    %tot     avg                alloc    %tot      avg
+───────────────────────────────────────────────────────────────────────────────────────────────────────────
+ sleep                         101   1.16s   41.4%  11.5ms  ███▍        16.7KiB    0.0%     169B
+ nest 2                          1   703ms   25.1%   703ms  ██             528B    0.0%     528B
+ ├─ level 2.2                    1   402ms   14.3%   402ms  █▏             112B    0.0%     112B
+ └─ level 2.1                    1   302ms   10.8%   302ms  ▉              112B    0.0%     112B
+ throwing                        1   502ms   17.9%   502ms  █▍             512B    0.0%     512B
+ nest 1                          1   399ms   14.2%   399ms  █▏          1.23KiB    0.0%  1.23KiB
+ ├─ level 2.2                    1   202ms    7.2%   202ms  ▋              400B    0.0%     400B
+ └─ level 2.1                    3  95.8ms    3.4%  31.9ms  ▎              336B    0.0%     112B
+ randoms                         1  35.7ms    1.3%  35.7ms  ▏           76.9MiB  100.0%  76.9MiB  ████████
+ line_profile @ example.jl       1  8.95μs    0.0%  8.95μs                 480B    0.0%     480B
+ ├─ L5: for i = 1:n              1  2.15μs    0.0%  2.15μs                 176B    0.0%     176B
+ │  └─ L6: x += i               10   103ns    0.0%  10.3ns                0.00B    0.0%    0.00B
+ └─ L4: x = 0                    1  16.0ns    0.0%  16.0ns                0.00B    0.0%    0.00B
+ foo                             1  16.0ns    0.0%  16.0ns                0.00B    0.0%    0.00B
+ funcdef                         1  15.0ns    0.0%  15.0ns                0.00B    0.0%    0.00B
+───────────────────────────────────────────────────────────────────────────────────────────────────────────
 ```
 
 It is also possible to manually start and stop a timed section.
@@ -174,11 +176,14 @@ The `print_timer([io::IO = stdout], to::TimerOutput, kwargs)`, (or `show`) takes
 
 * `title::String` ─ title for the timer
 * `columns::Vector{Symbol}` ─ exactly which columns to show, in order. Available:
-  `:ncalls`, `:time`, `:time_pct`, `:time_par`, `:time_avg`,
-  `:allocs`, `:allocs_pct`, `:allocs_par`, `:allocs_avg`, and `:spacer` (an empty
-  gap column). For example `columns = [:ncalls, :time, :time_pct, :time_par]`
+  `:ncalls`, `:time`, `:time_pct`, `:time_par`, `:time_avg`, `:time_bar`,
+  `:allocs`, `:allocs_pct`, `:allocs_par`, `:allocs_avg`, `:allocs_bar`, and `:spacer` (an empty
+  gap column). For example `columns = [:ncalls, :time, :time_pct, :time_par]`.
+  The `_bar` columns show each section's share of the total as a bar, colored
+  from blue (cheap) to red (expensive) in color-capable terminals
 * `allocations::Bool` ─ show the allocation columns (default `true`); shorthand for a `columns` selection
-* `compact::Bool` ─ hide the `avg` columns (default `false`); shorthand for a `columns` selection
+* `compact::Bool` ─ hide the `avg` and bar columns (default `false`); shorthand for a `columns` selection
+* `bars::Bool` ─ show the bar columns (default `true`); shorthand for a `columns` selection
 * `sortby::Symbol` ─ sort the sections according to `:time` (default), `:ncalls`, `:allocations`, `:name` or `:firstexec`
 * `linechars::Symbol` ─ use either `:unicode` (default) or `:ascii` for a pure ASCII table
 * `maxdepth::Int` ─ only print sections nested up to this depth (default: no limit)

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -3,7 +3,7 @@ module TimerOutputs
 using ExprTools: splitdef, combinedef
 using Printf: @sprintf
 using PrettyTables: pretty_table, MultiColumn, EmptyCells, TextTableFormat, TextTableStyle,
-    TextHighlighter, text_table_borders__compact, @text__no_vertical_lines, @crayon_str
+    TextHighlighter, text_table_borders__compact, @text__no_vertical_lines, @crayon_str, Crayon
 import Tables
 
 import Base: show, time_ns

--- a/src/printing.jl
+++ b/src/printing.jl
@@ -90,6 +90,47 @@ function prettycount(t::Integer)
     return str
 end
 
+########
+# Heat #
+########
+
+# Heat color for a section's share of the total: cold sections fade toward
+# blue, hot ones ramp through orange to red, and the middle band keeps the
+# terminal's default color. The sqrt spreads out the small percentages most
+# sections live at, so they don't all collapse into the blue end.
+const COLD_STOPS = ((59, 76, 192), (110, 130, 180))
+const HOT_STOPS = ((200, 120, 90), (210, 60, 60), (200, 10, 30))
+const COLD_MAX = 0.35 # in sqrt space: below ~12% of the total is "cold"
+const HOT_MIN = 0.6  # in sqrt space: above ~36% of the total is "hot"
+
+# piecewise-linear interpolation through the color stops, t in [0, 1]
+function lerp_stops(stops, t)
+    x = t * (length(stops) - 1)
+    i = clamp(floor(Int, x) + 1, 1, length(stops) - 1)
+    s = x - (i - 1)
+    a, b = stops[i], stops[i + 1]
+    return ntuple(k -> round(Int, a[k] + (b[k] - a[k]) * s), 3)
+end
+
+function heat_crayon(frac)
+    t = sqrt(clamp(frac, 0.0, 1.0))
+    t < COLD_MAX && return Crayon(foreground = lerp_stops(COLD_STOPS, t / COLD_MAX))
+    t > HOT_MIN && return Crayon(foreground = lerp_stops(HOT_STOPS, (t - HOT_MIN) / (1 - HOT_MIN)))
+    return Crayon()
+end
+
+# A fixed-width bar filled proportionally to `frac`, quasi-continuous through
+# eighth blocks, with the remainder left empty; the heat highlighter colors it
+const BAR_EIGHTHS = ("▏", "▎", "▍", "▌", "▋", "▊", "▉")
+
+function heatbar(frac, ascii::Bool; width::Int = 8)
+    frac = clamp(frac, 0.0, 1.0)
+    ascii && return rpad(repeat('#', round(Int, frac * width)), width, '.')
+    full, part = divrem(round(Int, frac * width * 8), 8)
+    bar = repeat('█', full) * (part == 0 ? "" : BAR_EIGHTHS[part])
+    return rpad(bar, width)
+end
+
 ##################
 # Table building #
 ##################
@@ -159,16 +200,20 @@ const COLUMNS = (;
     allocs_pct = ColumnSpec("%tot", "Allocations", true, (c, p, ctx) -> prettypercent(c.allocs, ctx.∑b)),
     allocs_par = ColumnSpec("%par", "Allocations", true, (c, p, ctx) -> ctx.toplevel ? "" : prettypar(c.allocs, p.allocs)),
     allocs_avg = ColumnSpec("avg", "Allocations", true, (c, p, ctx) -> prettymemory(c.allocs / c.ncalls)),
+    time_bar = ColumnSpec("", "Time", true, (c, p, ctx) -> heatbar(ctx.∑t > 0 ? c.time / ctx.∑t : 0.0, ctx.ascii)),
+    allocs_bar = ColumnSpec("", "Allocations", true, (c, p, ctx) -> heatbar(ctx.∑b > 0 ? c.allocs / ctx.∑b : 0.0, ctx.ascii)),
 )
 
-# the selection the `allocations` and `compact` keywords correspond to;
-# the %par columns are opt-in through the `columns` keyword
-function default_columns(allocations::Bool, compact::Bool)
+# the selection the `allocations`, `compact` and `bars` keywords correspond
+# to; the %par columns are opt-in through the `columns` keyword
+function default_columns(allocations::Bool, compact::Bool, bars::Bool)
     columns = [:ncalls, :time, :time_pct]
     compact || push!(columns, :time_avg)
+    compact || !bars || push!(columns, :time_bar)
     if allocations
         append!(columns, [:spacer, :allocs, :allocs_pct])
         compact || push!(columns, :allocs_avg)
+        compact || !bars || push!(columns, :allocs_bar)
     end
     return columns
 end
@@ -240,7 +285,8 @@ end
 # the indices of complement rows for the highlighter. `extra` is a synthetic
 # complement row to show among the children of `s`.
 function table_rows!(
-        rows::Vector{Vector{String}}, gray::Vector{Int}, s::Section, ∑t, ∑b,
+        rows::Vector{Vector{String}}, gray::Vector{Int}, heats::Vector{NTuple{2, Float64}},
+        s::Section, ∑t, ∑b,
         prefix::String, depth::Int, opts::TableOptions, extra::Union{ComplementRow, Nothing}
     )
     depth > opts.maxdepth && return rows
@@ -262,6 +308,7 @@ function table_rows!(
             row[k + 1] = blank && column.blankable ? "" : column.cell(child, s, ctx)
         end
         push!(rows, row)
+        push!(heats, (∑t > 0 ? child.time / ∑t : 0.0, ∑b > 0 ? child.allocs / ∑b : 0.0))
         synthetic && push!(gray, length(rows))
         child_extra = if opts.complement && !synthetic && !isempty(child.children)
             ComplementRow(complement_section(child), true)
@@ -269,7 +316,7 @@ function table_rows!(
             nothing
         end
         child_prefix = toplevel ? "" : string(prefix, islast ? opts.guides[4] : opts.guides[3])
-        table_rows!(rows, gray, child, ∑t, ∑b, child_prefix, depth + 1, opts, child_extra)
+        table_rows!(rows, gray, heats, child, ∑t, ∑b, child_prefix, depth + 1, opts, child_extra)
     end
     return rows
 end
@@ -309,7 +356,7 @@ function Base.show(io::IO, s::Section; kwargs...)
     return show_table(io, s; kwargs...)
 end
 
-function validated_options(; sortby, allocations, compact, columns, linechars, maxdepth, complement)
+function validated_options(; sortby, allocations, compact, bars, columns, linechars, maxdepth, complement)
     sortby in SORTBY_OPTIONS ||
         throw(ArgumentError("sortby should be :time, :allocations, :ncalls, :name, or :firstexec, got $sortby"))
     linechars in (:unicode, :ascii) ||
@@ -318,7 +365,7 @@ function validated_options(; sortby, allocations, compact, columns, linechars, m
         throw(ArgumentError("maxdepth should be at least 1, got $maxdepth"))
     # like 0.5, the most minimal selection also drops the header block
     header = !(compact && !allocations && columns === nothing)
-    columns = resolve_columns(columns === nothing ? default_columns(allocations, compact) : columns)
+    columns = resolve_columns(columns === nothing ? default_columns(allocations, compact, bars) : columns)
     return TableOptions(
         sortby, columns, linechars === :ascii, maxdepth, complement, header,
         tree_guides(linechars)
@@ -331,11 +378,11 @@ has_group(opts::TableOptions, group::String) = any(c -> c.group == group, opts.c
 function show_table(
         io::IO, to::TimerOutput;
         sortby::Symbol = :time, allocations::Bool = true, compact::Bool = false,
-        columns::Union{Nothing, AbstractVector{Symbol}} = nothing,
+        bars::Bool = true, columns::Union{Nothing, AbstractVector{Symbol}} = nothing,
         linechars::Symbol = :unicode, maxdepth::Int = typemax(Int),
         complement::Bool = false, title::String = ""
     )
-    opts = validated_options(; sortby, allocations, compact, columns, linechars, maxdepth, complement)
+    opts = validated_options(; sortby, allocations, compact, bars, columns, linechars, maxdepth, complement)
 
     Δt = time_ns() - to.start_time
     Δb = gc_bytes() - to.start_allocs
@@ -370,11 +417,11 @@ end
 function show_table(
         io::IO, s::Section;
         sortby::Symbol = :time, allocations::Bool = true, compact::Bool = false,
-        columns::Union{Nothing, AbstractVector{Symbol}} = nothing,
+        bars::Bool = true, columns::Union{Nothing, AbstractVector{Symbol}} = nothing,
         linechars::Symbol = :unicode, maxdepth::Int = typemax(Int),
         complement::Bool = false, title::String = ""
     )
-    opts = validated_options(; sortby, allocations, compact, columns, linechars, maxdepth, complement)
+    opts = validated_options(; sortby, allocations, compact, bars, columns, linechars, maxdepth, complement)
     ∑t, ∑b = s.ncalls > 0 ? (s.time, s.allocs) : totmeasured(s)
     # `_show_table` renders the children of its root. Wrap the section in a
     # detached display-only root so the section itself is the first row.
@@ -421,7 +468,8 @@ end
 function _show_table(io::IO, s::Section, ∑t, ∑b, opts::TableOptions, title, totals, extra)
     rows = Vector{Vector{String}}()
     gray = Int[]
-    table_rows!(rows, gray, s, ∑t, ∑b, "", 1, opts, extra)
+    heats = NTuple{2, Float64}[]
+    table_rows!(rows, gray, heats, s, ∑t, ∑b, "", 1, opts, extra)
 
     labels = String["Section"; [c.label for c in opts.columns]]
     ncols = length(labels)
@@ -451,6 +499,30 @@ function _show_table(io::IO, s::Section, ∑t, ∑b, opts::TableOptions, title, 
         permutedims(reduce(hcat, rows))
     end
 
+    # complement rows are shown in gray (first match wins, so gray beats heat)
+    highlighters = TextHighlighter[]
+    if !isempty(gray)
+        grayset = Set(gray)
+        push!(highlighters, TextHighlighter((_, i, _) -> i in grayset, crayon"dark_gray"))
+    end
+    # the bar columns are colored by their share of the total
+    heat_which = Dict{Int, Int}() # data column index -> which fraction (1 = time, 2 = allocs)
+    for (k, c) in enumerate(opts.columns)
+        if c === COLUMNS.time_bar
+            heat_which[k + 1] = 1
+        elseif c === COLUMNS.allocs_bar
+            heat_which[k + 1] = 2
+        end
+    end
+    if !isempty(heat_which)
+        push!(
+            highlighters, TextHighlighter(
+                (_, i, j) -> haskey(heat_which, j),
+                (h, _, i, j) -> heat_crayon(heats[i][heat_which[j]])
+            )
+        )
+    end
+
     pretty_table(
         io, data;
         column_labels = column_labels,
@@ -474,13 +546,7 @@ function _show_table(io::IO, s::Section, ∑t, ∑b, opts::TableOptions, title, 
             merged_column_label = crayon"default",
             column_label = crayon"default"
         ),
-        # complement rows are shown in gray
-        highlighters = if isempty(gray)
-            TextHighlighter[]
-        else
-            grayset = Set(gray)
-            [TextHighlighter((_, i, _) -> i in grayset, crayon"dark_gray")]
-        end,
+        highlighters = highlighters,
         # crop to the display width in the REPL and on terminals so long
         # section names never make lines wrap (#166); the Section column is
         # shrunk first so the numeric columns survive

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@ using TimerOutputs
 using Test
 
 import TimerOutputs: DEFAULT_TIMER, ncalls, flatten,
-    prettytime, prettymemory, prettypercent, prettycount, todict
+    prettytime, prettymemory, prettypercent, prettycount, todict,
+    heatbar, heat_crayon
 
 using FlameGraphs
 
@@ -1067,12 +1068,60 @@ end
         split(
         header_line(
             render(;
-                columns = [:ncalls, :time, :time_pct, :time_avg, :spacer, :allocs, :allocs_pct, :allocs_avg]
+                columns = [
+                    :ncalls, :time, :time_pct, :time_avg, :time_bar,
+                    :spacer, :allocs, :allocs_pct, :allocs_avg, :allocs_bar,
+                ]
             )
         )
     )
 
     @test_throws ArgumentError render(; columns = [:bogus])
+end
+
+@testset "heat bar columns" begin
+    # bar rendering: eighth-block resolution, empty remainder
+    @test heatbar(0.0, false) == " "^8
+    @test heatbar(0.5, false) == "████    "
+    @test heatbar(1 / 16, false) == "▌       "
+    @test heatbar(1.0, false) == "█"^8
+    @test heatbar(2.0, false) == "█"^8 # clamped
+    @test heatbar(0.5, false; width = 4) == "██  "
+    # ascii mode keeps a track to show the extent in colorless logs
+    @test heatbar(0.5, true) == "####...."
+
+    # color ramp: cold -> blue, middle band -> default, hot -> red
+    @test heat_crayon(0.0) == TimerOutputs.Crayon(foreground = (59, 76, 192))
+    @test heat_crayon(1.0) == TimerOutputs.Crayon(foreground = (200, 10, 30))
+    @test heat_crayon(0.2) == TimerOutputs.Crayon() # sqrt(0.2) ≈ 0.45 is inside the uncolored band
+
+    to = TimerOutput()
+    @timeit to "a" @timeit to "b" 1 + 1
+
+    # bars are in the default columns, dropped by compact or bars = false
+    str = sprint(show, to)
+    @test occursin("█", str)
+    @test !occursin("█", sprint((io, x) -> show(io, x; compact = true), to))
+    nobars = sprint((io, x) -> show(io, x; bars = false), to)
+    @test !occursin("█", nobars) && occursin("avg", nobars)
+    # the bar glyphs render but no escape codes are emitted without color
+    @test !occursin("\e[", str)
+    # with color the bar cells get a truecolor foreground
+    cstr = sprint(show, to; context = :color => true)
+    @test occursin("\e[38;2;", cstr)
+
+    # opt-in through the columns keyword
+    sel = sprint((io, x) -> show(io, x; columns = [:ncalls, :time, :time_bar]), to)
+    @test occursin("█", sel) && !occursin("alloc", sel)
+
+    # a displayed subsection is its own 100% reference: full bar
+    @test occursin("█"^8, sprint(show, to["a"]))
+
+    # complement rows stay gray, never heat colored
+    ccstr = sprint((io, x) -> show(io, x; complement = true), to; context = :color => true)
+    for line in split(ccstr, '\n')
+        occursin('~', line) && @test occursin("\e[90m", line)
+    end
 end
 
 @testset "totals row styling" begin


### PR DESCRIPTION
The default table now shows a small bar per section visualizing its share of the total time / allocations, colored from blue (cheap) to red (hot) in color-capable terminals. Displaying a subsection rescales the bars to that subsection's total. Opt out with `bars = false` (`compact = true` also drops them), or select explicitly via `columns` (`:time_bar`, `:allocs_bar`).