### PR TITLE
allow one to directly time a call, using the call as the section name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ internals may need updating (see "Internal changes" below).
 * **GC time column**: `print_timer(to; gc = true)` (or the `:gc_time` column)
   adds a column with the time spent in garbage collection within each section.
   Off by default. Also available programmatically as `TimerOutputs.gctime(to)`.
+* **Call shorthand**: `@timeit to foo(args)` times the call under a label
+  derived from the callee (here `"foo"`), a shorthand for
+  `@timeit to "foo" foo(args)`. Works with the default timer too
+  (`@timeit foo(args)`). Qualified calls keep their qualification
+  (`Mod.foo` → `"Mod.foo"`); operators and other non-name calls still need an
+  explicit label.
 * **`maxdepth` keyword**: limit how deeply nested sections are printed.
 * **`complement = true` display option**: show what was *not* timed, in gray —
   an `~untimed~` row for the wall time outside all sections, and a `~name~`

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ end
 
 funcdef(2)
 
+# Timing a function call with no label uses the callee's name as the label,
+# i.e. this is shorthand for @timeit to "sum" sum(1:100)
+@timeit to sum(1:100)
+
 # @timeit_all additionally times every statement in a block or function body
 @timeit_all to function line_profile(n)
     x = 0
@@ -157,6 +161,7 @@ Similar information is available for allocations:
  ├─ L5: for i = 1:n              1  2.15μs    0.0%  2.15μs                 176B    0.0%     176B
  │  └─ L6: x += i               10   103ns    0.0%  10.3ns                0.00B    0.0%    0.00B
  └─ L4: x = 0                    1  16.0ns    0.0%  16.0ns                0.00B    0.0%    0.00B
+ sum                             1  22.0ns    0.0%  22.0ns                0.00B    0.0%    0.00B
  foo                             1  16.0ns    0.0%  16.0ns                0.00B    0.0%    0.00B
  funcdef                         1  15.0ns    0.0%  15.0ns                0.00B    0.0%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -19,9 +19,14 @@
 """
     @timeit [to::TimerOutput] label codeblock
     @timeit [to::TimerOutput] [label] function ... end
+    @timeit [to::TimerOutput] funccall(args...)
 
 Time the code block or function body under `label`, accumulating into `to`
 (the default timer if not given). Returns the value of the timed expression.
+
+When the timed expression is a plain or qualified function call and no label is
+given, the label is derived from the callee, so `@timeit to foo(x)` is shorthand
+for `@timeit to "foo" foo(x)`.
 """
 macro timeit(args...)
     return timer_expr(__source__, __module__, false, args...)
@@ -57,14 +62,18 @@ default_timer_expr() = :($(TimerOutputs).DEFAULT_TIMER)
 
 timer_expr(::LineNumberNode, ::Module, ::Bool, args...) = throw(ArgumentError(TIMEIT_USAGE))
 
-# one macro argument: only valid for function definitions
+# one macro argument: a function definition, or `@timeit foo(args)` timing a
+# call under a label derived from the callee (#159)
 function timer_expr(source::LineNumberNode, mod::Module, is_debug::Bool, ex)
-    is_func_def(ex) || throw(ArgumentError(TIMEIT_USAGE))
-    return timed_function_expr(source, mod, is_debug, default_timer_expr(), nothing, ex)
+    is_func_def(ex) && return timed_function_expr(source, mod, is_debug, default_timer_expr(), nothing, ex)
+    label = call_label(ex)
+    label === nothing && throw(ArgumentError(TIMEIT_USAGE))
+    return timed_block_expr(source, mod, is_debug, default_timer_expr(), label, ex)
 end
 
 # two macro arguments: (label, ex), or for function definitions (to, funcdef)
-# unless the first argument is a literal label
+# unless the first argument is a literal label, or `@timeit to foo(args)` timing
+# a call on `to` under a label derived from the callee (#159)
 function timer_expr(source::LineNumberNode, mod::Module, is_debug::Bool, to_or_label, ex)
     if is_func_def(ex)
         if to_or_label isa String
@@ -72,6 +81,14 @@ function timer_expr(source::LineNumberNode, mod::Module, is_debug::Bool, to_or_l
         else
             return timed_function_expr(source, mod, is_debug, to_or_label, nothing, ex)
         end
+    end
+    # `@timeit to call(args)`: derive the label from the call and keep the timer.
+    # Only when the first argument isn't itself a (literal or interpolated) label
+    # and the body is a plain/qualified function call; otherwise the first
+    # argument is the label and the default timer is used, as before.
+    if !is_label_expr(to_or_label)
+        label = call_label(ex)
+        label === nothing || return timed_block_expr(source, mod, is_debug, to_or_label, label, ex)
     end
     return timed_block_expr(source, mod, is_debug, default_timer_expr(), to_or_label, ex)
 end
@@ -86,6 +103,31 @@ end
 
 function is_func_def(ex)
     return ex isa Expr && (ex.head === :function || Base.is_short_function_def(ex))
+end
+
+# a literal or string-interpolation label (`"foo"`, `"foo_$i"`); anything else in
+# the first position of a two-argument `@timeit` is taken to be the timer
+is_label_expr(x) = x isa String || (x isa Expr && x.head === :string)
+
+# The label #159 derives from a timed call: the callee spelled as written, for a
+# plain (`foo(args)` -> "foo") or qualified (`Mod.foo(args)` -> "Mod.foo") call.
+# Operators, broadcasts, constructors with type parameters, indexing, etc. return
+# `nothing`, so those still require an explicit label.
+function call_label(ex)
+    (ex isa Expr && ex.head === :call && !isempty(ex.args)) || return nothing
+    return callee_name(ex.args[1])
+end
+
+function callee_name(callee)
+    if callee isa Symbol
+        return Base.isidentifier(callee) ? string(callee) : nothing
+    elseif callee isa Expr && callee.head === :. && length(callee.args) == 2 && callee.args[2] isa QuoteNode
+        left = callee_name(callee.args[1])
+        right = callee.args[2].value
+        (left === nothing || !(right isa Symbol) || !Base.isidentifier(right)) && return nothing
+        return string(left, ".", right)
+    end
+    return nothing
 end
 
 # The full timed expression: run `ex` under section `label` of timer `to`,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -951,11 +951,41 @@ end
     @test (@timeit to "nothing" nothing) === nothing
     @test ncalls(to["lit"]) == 1
     # invalid forms give the friendly usage error
-    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit f(x)))
     @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit 42))
     @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit))
+    # a call body with no derivable label (operator, indexing) still errors
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit a + b))
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timeit a[i]))
     # an empty timer still renders
     @test sprint(show, TimerOutput()) isa String
+end
+
+@testset "call shorthand (#159)" begin
+    g(x) = x + 1
+
+    # 1-arg: default timer, label derived from the callee
+    reset_timer!()
+    @test (@timeit g(41)) == 42
+    @test ncalls(DEFAULT_TIMER["g"]) == 1
+
+    # 2-arg: explicit timer, label derived from the callee
+    to = TimerOutput()
+    @test (@timeit to g(41)) == 42
+    @test ncalls(to["g"]) == 1
+
+    # qualified calls keep the qualification in the label
+    @test (@timeit to Base.identity(3)) == 3
+    @test ncalls(to["Base.identity"]) == 1
+
+    # an explicit (literal or interpolated) label is never treated as a timer
+    i = 2
+    @timeit to "lit" g(0)
+    @timeit to "iter_$i" g(0)
+    @test ncalls(to["lit"]) == 1 && ncalls(to["iter_2"]) == 1
+
+    # composes with the zero-overhead NoTimerOutput
+    nt = NoTimerOutput()
+    @test (@timeit nt g(41)) == 42
 end
 
 @testset "ascii output is pure ASCII (#115)" begin


### PR DESCRIPTION
Fixes https://github.com/KristofferC/TimerOutputs.jl/issues/159