### PR TITLE
add @timed_testset, a timed drop-in for Test.@testset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ internals may need updating (see "Internal changes" below).
   (`@timeit foo(args)`). Qualified calls keep their qualification
   (`Mod.foo` → `"Mod.foo"`); operators and other non-name calls still need an
   explicit label.
+* **`@timed_testset`**: a drop-in replacement for `Test.@testset` that times
+  each set (nested sets nest in the timer), so `print_timer()` after the tests
+  shows where the test time went. `Test` stays a non-dependency; the emitted
+  `@testset` is resolved at the call site.
 * **`maxdepth` keyword**: limit how deeply nested sections are printed.
 * **`complement = true` display option**: show what was *not* timed, in gray —
   an `~untimed~` row for the wall time outside all sections, and a `~name~`

--- a/README.md
+++ b/README.md
@@ -175,6 +175,31 @@ foo()
 end_timed_section!(to, section)
 ```
 
+## Timing test sets
+
+`@timed_testset` is a drop-in replacement for `Test.@testset` that also times
+each set, so `print_timer()` after the tests shows where the test time went.
+Replace `@testset` with `@timed_testset` and, at the end of `runtests.jl`, print
+the default timer:
+
+```julia
+using Test, TimerOutputs
+
+@timed_testset "trig" begin
+    @timed_testset "sin" begin
+        @test sin(0) == 0
+    end
+    @timed_testset "cos" begin
+        @test cos(0) == 1
+    end
+end
+
+print_timer()  # or e.g. @timed_testset to "trig" begin ... end to use another timer
+```
+
+`Test` is not a dependency of TimerOutputs; the emitted `@testset` is resolved at
+the call site, so `using Test` there is enough.
+
 ## Settings for printing:
 
 The `print_timer([io::IO = stdout], to::TimerOutput, kwargs)`, (or `show`) takes a number of keyword arguments to change the output. They are listed here:

--- a/src/TimerOutputs.jl
+++ b/src/TimerOutputs.jl
@@ -8,7 +8,7 @@ import Tables
 
 import Base: show, time_ns
 
-export TimerOutput, NoTimerOutput, @timeit, @timeit_debug, @timeit_all,
+export TimerOutput, NoTimerOutput, @timeit, @timeit_debug, @timeit_all, @timed_testset,
     reset_timer!, print_timer, timeit, enable_timer!, disable_timer!, @notimeit,
     get_timer, begin_timed_section!, end_timed_section!
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -277,6 +277,54 @@ function notimeit_expr(to, ex::Expr)
     end
 end
 
+##################
+# @timed_testset #
+##################
+
+"""
+    @timed_testset [to::TimerOutput] "title" [options...] body
+
+Run a `Test.@testset` while timing it under `title` in `to` (the default timer
+if not given). A drop-in replacement for `@testset`: any options and the body
+are forwarded verbatim, and nested `@timed_testset`s nest in the timer, so
+`print_timer()` after the tests shows where test time went.
+
+Requires `Test` to be loaded at the call site (it is not a dependency of
+TimerOutputs); the emitted `@testset` is resolved there.
+
+```julia
+@timed_testset "trig" begin
+    @timed_testset "sin" begin
+        @test sin(0) == 0
+    end
+    @timed_testset "cos" begin
+        @test cos(0) == 1
+    end
+end
+```
+"""
+macro timed_testset(args...)
+    return timed_testset_expr(__source__, __module__, args...)
+end
+
+const TIMED_TESTSET_USAGE = "invalid macro usage for @timed_testset, use as @timed_testset [to] \"title\" [options...] body"
+
+function timed_testset_expr(source::LineNumberNode, mod::Module, args...)
+    length(args) >= 2 || throw(ArgumentError(TIMED_TESTSET_USAGE))
+    # a leading string is the title (default timer); otherwise it is the timer
+    if is_label_expr(args[1])
+        to, title, rest = default_timer_expr(), args[1], args[2:end]
+    else
+        length(args) >= 3 || throw(ArgumentError(TIMED_TESTSET_USAGE))
+        to, title, rest = args[1], args[2], args[3:end]
+    end
+    # emit an unqualified `@testset` so it resolves in the caller's module; the
+    # surrounding machinery escapes it. `title` labels the timer section and
+    # names the testset.
+    testset = Expr(:macrocall, Symbol("@testset"), source, title, rest...)
+    return timed_block_expr(source, mod, false, to, title, testset)
+end
+
 ###############
 # @timeit_all #
 ###############

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1444,4 +1444,56 @@ const timeit_all_error_line = @__LINE__() - 2
     @test any(f -> f.line == timeit_all_error_line && endswith(String(f.file), "runtests.jl"), st)
 end
 
+@testset "@timed_testset (#165)" begin
+    to = TimerOutput()
+    ran = Ref(0)
+
+    # explicit timer; nested timed testsets nest in the timer and the bodies run
+    @timed_testset to "outer" begin
+        @timed_testset to "inner 1" begin
+            ran[] += 1
+            @test true
+        end
+        @timed_testset to "inner 2" begin
+            ran[] += 1
+            @test 1 + 1 == 2
+        end
+    end
+    @test ran[] == 2
+    @test ncalls(to["outer"]) == 1
+    @test haskey(to["outer"].inner_timers, "inner 1")
+    @test haskey(to["outer"].inner_timers, "inner 2")
+
+    # testset options are forwarded verbatim to @testset
+    @timed_testset to "opts" verbose = true begin
+        @test true
+    end
+    @test ncalls(to["opts"]) == 1
+
+    # a `for` testset body runs per iteration but is timed once
+    @timed_testset to "loop" for i in 1:3
+        @test i > 0
+    end
+    @test ncalls(to["loop"]) == 1
+
+    # an interpolated title reads as a label, not the timer
+    label = "dynamic"
+    @timed_testset to "$label" begin
+        @test true
+    end
+    @test haskey(to.inner_timers, "dynamic")
+
+    # no explicit timer -> default timer
+    reset_timer!()
+    @timed_testset "default" begin
+        @test true
+    end
+    @test haskey(DEFAULT_TIMER.inner_timers, "default")
+    reset_timer!()
+
+    # invalid forms give the usage error
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timed_testset "onlytitle"))
+    @test_throws ArgumentError macroexpand(@__MODULE__, :(@timed_testset))
+end
+
 include("test_coverage.jl")


### PR DESCRIPTION
Times each testset under its title in a timer (default if not given), nesting like the tests. Emits an unqualified `@testset` resolved at the call site, so Test stays a non-dependency.

Fixes #165