### PR TITLE
Bump version from 0.5.30 to 1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TimerOutputs"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.30"
+version = "1.0.0"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"


### PR DESCRIPTION
Fixes https://github.com/KristofferC/TimerOutputs.jl/issues/203