### PR TITLE
fix @label in a timed body (#228)

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -172,27 +172,73 @@ end
 # does not elide an empty try/finally. Splicing `ex` verbatim (rather than
 # behind a closure or temporary) also preserves its line numbers and lets
 # `return`, `break`, `continue` and assignments behave as in the unwrapped code.
-function timed_section(to, label, ex, srcfile::Union{String, Nothing} = nothing)
+# A `@label` is the one thing that cannot be duplicated, so bodies defining one
+# take the `single_copy_section` variant below.
+function timed_section(to, label, ex, srcfile::Union{String, Nothing} = nothing, debug_mod::Union{Module, Nothing} = nothing)
     @gensym to_local enabled data b₀ t₀ g₀
     # `@timeit_all` sections record the source file their label refers to
     push_call = srcfile === nothing ? :($(push!)($to_local, $label)) :
         :($(push_srcfile!)($to_local, $label, $srcfile))
+    start = Any[
+        :($data = $push_call),
+        :($g₀ = $(gc_time)()),
+        :($b₀ = $(gc_bytes)()),
+        :($t₀ = $(time_ns)()),
+    ]
     cleanup = quote
         $(do_accumulate!)($data, $t₀, $b₀, $g₀)
         $(pop!)($to_local)
     end
-    return quote
+    if defines_label(ex)
+        return single_copy_section(debug_mod, to, ex, to_local, enabled, start, cleanup)
+    end
+    core = quote
         $to_local = $to
         $enabled = $(isenabled)($to_local)
         if $enabled
-            $data = $push_call
-            $g₀ = $(gc_time)()
-            $b₀ = $(gc_bytes)()
-            $t₀ = $(time_ns)()
+            $(start...)
             $(Expr(:tryfinally, ex, cleanup))
         else
             $ex
         end
+    end
+    debug_mod === nothing && return core
+    return debug_gated(debug_mod, core, ex)
+end
+
+# Duplicating a body that defines a `@label` is a syntax error (#228), so such
+# bodies get a single copy of `ex` with an unconditional try/finally, `enabled`
+# deciding at run time whether to accumulate. Not the default because the
+# try/finally then survives even when `isenabled(to)` folds to `false`, which
+# costs a little on Julia 1.10.
+function single_copy_section(debug_mod::Union{Module, Nothing}, to, ex, to_local, enabled, start::Vector{Any}, cleanup)
+    init = quote
+        $to_local = $to
+        $enabled = $(isenabled)($to_local)
+        if $enabled
+            $(start...)
+        end
+    end
+    if debug_mod !== nothing
+        # keep `to` unevaluated when debug timings are off, as `debug_gated` does
+        init = quote
+            $enabled = false
+            if $debug_mod.timeit_debug_enabled()
+                $init
+            end
+        end
+    end
+    return quote
+        $init
+        $(
+            Expr(
+                :tryfinally, ex, quote
+                    if $enabled
+                        $cleanup
+                    end
+                end
+            )
+        )
     end
 end
 
@@ -211,16 +257,12 @@ end
 # `@timeit to label ex` for code blocks. The whole expression is escaped so the
 # user code (and its line numbers) survives verbatim into stacktraces and coverage.
 function timed_block_expr(source::LineNumberNode, mod::Module, is_debug::Bool, to, label, ex)
-    core = timed_section(to, label, ex)
-    is_debug && (core = debug_gated(mod, core, ex))
-    return Expr(:block, source, esc(core))
+    return Expr(:block, source, esc(timed_section(to, label, ex, nothing, is_debug ? mod : nothing)))
 end
 
 # an (unescaped) expression that times `ex` and evaluates to its value
 function timed_value_expr(mod::Module, is_debug::Bool, to, label, ex, srcfile::Union{String, Nothing} = nothing)
-    core = timed_section(to, label, ex, srcfile)
-    is_debug && (core = debug_gated(mod, core, ex))
-    return core
+    return timed_section(to, label, ex, srcfile, is_debug ? mod : nothing)
 end
 
 # `@timeit [to] [label] function f() ... end`
@@ -470,6 +512,14 @@ function macro_name(ex::Expr)
         name = name.name
     end
     return name
+end
+
+# `ex` defines a label, so it may not be duplicated
+function defines_label(ex)
+    ex isa Expr || return false
+    ex.head === :symboliclabel && return true
+    ex.head === :macrocall && macro_name(ex) === Symbol("@label") && return true
+    return any(defines_label, ex.args)
 end
 
 # Jumping across a `tryfinally` boundary is a lowering error, so a statement

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1053,8 +1053,11 @@ end
     @test Debug228.goto_block(4) == 4
     @test isempty(Debug228.to.inner_timers)
     TimerOutputs.enable_debug_timings(Debug228)
-    @test Debug228.goto_func(3) == 3
-    @test Debug228.goto_block(4) == 4
+    # `invokelatest` so the enable above is visible even though the `@allocated`
+    # earlier in this testset forces the whole thunk to compile at a fixed world
+    # age on Julia < 1.12
+    @test Base.invokelatest(Debug228.goto_func, 3) == 3
+    @test Base.invokelatest(Debug228.goto_block, 4) == 4
     @test ncalls(Debug228.to["goto_func"]) == 1
     @test ncalls(Debug228.to["goto_block"]) == 1
     TimerOutputs.disable_debug_timings(Debug228)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -958,6 +958,108 @@ const dbg_168_error_line = @__LINE__() - 2
     @test any(f -> f.line == dbg_168_error_line && endswith(String(f.file), "runtests.jl"), st)
 end
 
+# a body defining a `@label` cannot be spliced into two branches (#228)
+const to_228 = TimerOutput()
+
+@timeit to_228 function goto_func_228(n)
+    i = 0
+    @label loop
+    i += 1
+    i < n && @goto loop
+    return i
+end
+
+function goto_block_228(n)
+    i = 0
+    @timeit to_228 "goto_block" begin
+        @label loop
+        i += 1
+        i < n && @goto loop
+    end
+    return i
+end
+
+@timeit_all to_228 function goto_all_228(n)
+    i = 0
+    @label loop
+    i += 1
+    i < n && @goto loop
+    return i
+end
+
+@timeit to_228 function goto_throw_228()
+    i = 0
+    @label loop
+    i += 1
+    i < 3 && @goto loop
+    error("boom")
+end
+
+@timeit TimerOutputs.NoTimerOutput() function goto_notimer_228(n)
+    i = 0
+    @label loop
+    i += 1
+    i < n && @goto loop
+    return i
+end
+
+module Debug228
+    using TimerOutputs
+    const to = TimerOutput()
+    @timeit_debug to function goto_func(n)
+        i = 0
+        @label loop
+        i += 1
+        i < n && @goto loop
+        return i
+    end
+    function goto_block(n)
+        i = 0
+        @timeit_debug to "goto_block" begin
+            @label loop
+            i += 1
+            i < n && @goto loop
+        end
+        return i
+    end
+end
+
+@testset "@label/@goto in a timed body (#228)" begin
+    @test goto_func_228(3) == 3
+    @test ncalls(to_228["goto_func_228"]) == 1
+    @test goto_block_228(4) == 4
+    @test ncalls(to_228["goto_block"]) == 1
+    @test goto_all_228(5) == 5
+    @test ncalls(to_228["goto_all_228"]) == 1
+    # every section opened above was closed again
+    @test isempty(to_228.timer_stack)
+
+    @test_throws ErrorException goto_throw_228()
+    @test ncalls(to_228["goto_throw_228"]) == 1
+    @test isempty(to_228.timer_stack)
+
+    # a disabled timer runs the body without timing it
+    disable_timer!(to_228)
+    @test goto_func_228(7) == 7
+    @test ncalls(to_228["goto_func_228"]) == 1
+    enable_timer!(to_228)
+
+    # `NoTimerOutput` still compiles away to nothing
+    @test goto_notimer_228(5) == 5
+    @test @allocated(goto_notimer_228(5)) == 0
+
+    # `@timeit_debug` does not evaluate its timer expression while disabled
+    @test Debug228.goto_func(3) == 3
+    @test Debug228.goto_block(4) == 4
+    @test isempty(Debug228.to.inner_timers)
+    TimerOutputs.enable_debug_timings(Debug228)
+    @test Debug228.goto_func(3) == 3
+    @test Debug228.goto_block(4) == 4
+    @test ncalls(Debug228.to["goto_func"]) == 1
+    @test ncalls(Debug228.to["goto_block"]) == 1
+    TimerOutputs.disable_debug_timings(Debug228)
+end
+
 @testset "reset_timer! inside a timed section (#172)" begin
     to = TimerOutput()
     @timeit to function foo_172(x)


### PR DESCRIPTION
Fixes #228.

The body of a timed section is spliced into both the enabled and the disabled branch, so a body defining a `@label` defines it twice. Bodies that define a label now get a single copy of the body with an unconditional `try`/`finally`, and a runtime flag decides whether to accumulate.

Fixing it in `timed_section` rather than at one call site covers all the affected forms — #229 fixes the first only:

| | master | #229 | here |
|---|---|---|---|
| `@timeit to function f() @label L … end` | ✗ | ✓ | ✓ |
| `@timeit to "s" begin @label L … end` | ✗ | ✗ | ✓ |
| `@timeit_all to function f() @label L … end` | ✗ | ✗ | ✓ |
| `@timeit_debug to "s" begin @label L … end` | ✗ | ✗ | ✓ |

It also avoids putting the body in a closure, which boxes captures, adds a stack frame, and shadows any user binding named `inner` (that last one already affects `@timeit_debug` on master — separate fix).

Expansions for bodies without a label are byte-identical to master. The cost is that the `try`/`finally` is no longer elided when `isenabled(to)` folds to `false`, which only matters on 1.10; `NoTimerOutput` still measures zero allocations.

Supersedes #229.