### PR TITLE
gensym the closure name in @timeit_debug function bodies

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -233,12 +233,15 @@ function timed_function_expr(source::LineNumberNode, mod::Module, is_debug::Bool
     end
     body = def[:body]
     wrapped = if is_debug
-        # the closure lets the debug-disabled branch reduce to a plain call
+        # the closure lets the debug-disabled branch reduce to a plain call. Its
+        # name is gensym'd since it lands in the user's scope, where a plain
+        # `inner` would shadow whatever the body means by that name.
+        @gensym inner
         quote
-            @inline function inner()
+            @inline function $inner()
                 $body
             end
-            $(timed_value_expr(mod, true, to, label, :(inner())))
+            $(timed_value_expr(mod, true, to, label, :($inner())))
         end
     else
         timed_value_expr(mod, false, to, label, body)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -948,14 +948,44 @@ const dbg_168_error_line = @__LINE__() - 2
     @test st[i].line == foo_168_error_line
     @test endswith(String(st[i].file), "runtests.jl")
 
-    # debug variant: the user body lives in the `inner` closure, but the error
-    # line must still be visible in the trace
+    # debug variant: the user body lives in a closure, but the error line must
+    # still be visible in the trace
     st = try
         dbg_168()
     catch
         stacktrace(catch_backtrace())
     end
     @test any(f -> f.line == dbg_168_error_line && endswith(String(f.file), "runtests.jl"), st)
+end
+
+# the closure `@timeit_debug` wraps a function body in must not collide with
+# names the body itself uses
+module DebugInner
+    using TimerOutputs
+    const to = TimerOutput()
+    inner(x) = 2x
+    @timeit_debug to function calls_inner(x)
+        return inner(x)
+    end
+    @timeit_debug to function arg_named_inner(inner)
+        return inner + 1
+    end
+    @timeit_debug to function local_named_inner(x)
+        inner = x + 1
+        return inner
+    end
+end
+
+@testset "closure name does not shadow user names" begin
+    @test DebugInner.calls_inner(3) == 6
+    @test DebugInner.arg_named_inner(3) == 4
+    @test DebugInner.local_named_inner(3) == 4
+    TimerOutputs.enable_debug_timings(DebugInner)
+    @test DebugInner.calls_inner(3) == 6
+    @test DebugInner.arg_named_inner(3) == 4
+    @test DebugInner.local_named_inner(3) == 4
+    @test ncalls(DebugInner.to["calls_inner"]) == 1
+    TimerOutputs.disable_debug_timings(DebugInner)
 end
 
 @testset "reset_timer! inside a timed section (#172)" begin


### PR DESCRIPTION
The closure `@timeit_debug` wraps a function body in is literally named `inner`, and the wrapper is escaped into the user's function, so `inner` becomes a local binding in their scope:

```julia
inner(x) = 2x

@timeit_debug to function f(x)
    return inner(x)      # MethodError: no method matching (::var"#inner#f##0"{Int64})(::Int64)
end

@timeit_debug to function g(inner)
    return inner + 1     # syntax: cannot add method to function argument inner
end
```

The first fails at run time, the second at definition time. Both happen whether or not debug timings are enabled, since the closure is emitted either way. `@gensym` the name so it can't clash.

Independent of #230, though that PR is why I noticed — it removes the reason to extend this closure to plain `@timeit`.