### PR TITLE
Let print_timer() print a Section

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -352,9 +352,9 @@ end
 ############
 
 print_timer(; kwargs...) = print_timer(stdout; kwargs...)
-print_timer(to::TimerOutput; kwargs...) = print_timer(stdout, to; kwargs...)
+print_timer(to::Union{TimerOutput, Section}; kwargs...) = print_timer(stdout, to; kwargs...)
 print_timer(io::IO; kwargs...) = print_timer(io, DEFAULT_TIMER; kwargs...)
-print_timer(io::IO, to::TimerOutput; kwargs...) = (show_table(io, to; kwargs...); println(io))
+print_timer(io::IO, to::Union{TimerOutput, Section}; kwargs...) = (show_table(io, to; kwargs...); println(io))
 
 Base.show(to::TimerOutput; kwargs...) = show(stdout, to; kwargs...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1914,4 +1914,16 @@ end
     @test_throws ArgumentError macroexpand(@__MODULE__, :(@timed_testset))
 end
 
+@testset "print_timer() for sections (#239)" begin
+    to = TimerOutput()
+
+    @timeit to "foo" begin
+        @timeit to "bar" 1 + 1
+    end
+
+    @test sprint(print_timer, to) != ""
+    @test sprint(print_timer, to["foo"]) != ""
+    @test sprint(print_timer, to["foo"]["bar"]) != ""
+end
+
 include("test_coverage.jl")


### PR DESCRIPTION
Allow `print_timer()` to print `Section` as well as `TimerOutput`.

The 1.0 update (I guess) meant that `to["foo"]` is a `Section`, not a `TimerOutput`. This meant that `print_timer(to["foo"])` errored. It would be possible to work around this by calling `show_table()` directly, but `print_timer()` is part of the public API and `show_table()` is not, so this looks like a bug. To reproduce (or see that it is fixed with this PR):
```julia
using TimerOutputs
to = TimerOutput()
@timeit to "foo" sleep(1)
print_timer(to["foo"])
```